### PR TITLE
help command, unit testing, tooling, and misc!

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,43 @@ PUT /api/v2/integrations/{integrationId}
 }
 ~~~
 
+## Development
 
+### Building
+Builds can be made for node/npm, browsers, and docs.  Builds are currently handled by gulp but are being transitioned to npm scripts along with the rest of the development tooling.
 
+#### Node/NPM:
+`gulp build`
 
+Artifacts are not committed to the repo.  This is run on npm install automatically for node development.
+
+#### Browsers:
+`gulp build-browser`
+
+Artifacts are not committed to the repo.  This output will eventually be pushed to bower and other CDNs.
+
+#### Docs:
+`gulp doc` or `npm run docs`
+
+Artifacts will be committed to the repo for easy consumption on github.
+
+### Testing/Running:
+
+`npm run watch:test` will start the tests and monitor for changes
+
+`gulp build-browser` and use the generated script in an app for live testing
+
+## Contributing
+1. Fork the repo
+1. Add your code (Don't forget the unit tests!)
+1. Run the docs build (occurs as part of a standard build) to update the docs
+1. Test your code
+  * `npm test` -or- `npm run watch:test`
+  * `npm build` and try the version in an app
+1. Rebase onto upstream/master
+1. Push your branch up to your remote
+  * Note: pre-push hooks will ensure your code lints, builds, and passes the test suite
+1. Open a PR to `https://github.com/MyPureCloud/client-app-sdk`
+
+## Credit
 Example Icons from http://www.flaticon.com/packs/color-communication designed by FreePik

--- a/doc/doc.md
+++ b/doc/doc.md
@@ -19,6 +19,9 @@ https://sdk-cdn.mypurecloud.com/client-apps/<taggedversion>/purecloud-client-app
 <dt><a href="#module_alerting">alerting</a></dt>
 <dd><p>Utilities for alerting users in the PureCloud Client</p>
 </dd>
+<dt><a href="#module_ui">ui</a></dt>
+<dd><p>Utilities for manipulating the PureCloud Client UI</p>
+</dd>
 <dt><a href="#module_users">users</a></dt>
 <dd><p>Utilities for interacting with users in the PureCloud Client</p>
 </dd>
@@ -54,6 +57,41 @@ var options = {
    messageType: "info"
 };
 purecloud.apps.alerting.showToastPopup("Hello world", "Hello world, how are you doing today?", options);
+~~~
+
+<a name="module_ui"></a>
+
+## ui
+Utilities for manipulating the PureCloud Client UI
+
+**Since**: 1.0.0  
+
+* [ui](#module_ui)
+    * [.showHelp()](#module_ui.showHelp)
+    * [.hideHelp()](#module_ui.hideHelp)
+
+<a name="module_ui.showHelp"></a>
+
+### ui.showHelp()
+Show the help UI.
+
+**Since**: 1.0.0  
+**Example**  
+
+~~~js
+purecloud.apps.ui.showHelp();
+~~~
+
+<a name="module_ui.hideHelp"></a>
+
+### ui.hideHelp()
+Hide the help UI.  Noop if already shown.
+
+**Since**: 1.0.0  
+**Example**  
+
+~~~js
+purecloud.apps.ui.hideHelp();
 ~~~
 
 <a name="module_users"></a>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,10 +5,11 @@
 var pkg = require('./package.json');
 
 var gulp = require('gulp');
+var gutil = require('gutil');
 var del = require('del');
 var fs   = require('fs');
 var babel = require('gulp-babel');
-var gulpJsdoc2md = require('gulp-jsdoc-to-markdown')
+var gulpJsdoc2md = require('gulp-jsdoc-to-markdown');
 var rename = require('gulp-rename');
 var replace = require('gulp-replace');
 var uglify = require('gulp-uglify');
@@ -37,14 +38,14 @@ var buildDoc = function(){
         partial: "./doc/partials//**/*.hbs"
     })) //uses dmd to create readme, can find templates here https://github.com/jsdoc2md/dmd/tree/master/partials
     .on('error', function (err) {
-      gutil.log(gutil.colors.red('jsdoc2md failed'), err.message)
+      gutil.log(gutil.colors.red('jsdoc2md failed'), err.message);
     })
     .pipe(rename(function (path) {
       path.extname = '.md';
       path.basename = 'doc';
     }))
     .pipe(replace(/```/g, '~~~'))  // play nicely with kramdown
-    .pipe(gulp.dest('doc'))
+    .pipe(gulp.dest('doc'));
 };
 
 var buildBrowser = function() {
@@ -70,7 +71,7 @@ gulp.task('build', ['clean'], build);
 
 gulp.task('build-browser', ['clean'], buildBrowser);
 
-gulp.task('doc', buildDoc);
+gulp.task('doc', ['build-browser'], buildDoc);
 
 gulp.task('watch', function() {
     var watcher = gulp.watch('src/**/*.js', function() {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,74 @@
+// Karma configuration
+// Generated on Mon Jun 13 2016 18:30:32 GMT-0400 (EDT)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine', 'browserify'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'src/**/*Spec.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+        'src/**/*Spec.js': ['browserify']
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS', 'Chrome'],
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity,
+
+    browserify: {
+        debug: true,
+        transform: [ ['babelify', {presets: ['es2015']}] ]
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -8,16 +8,26 @@
     "lib": "src"
   },
   "scripts": {
-    "lint": "jshint src",
-    "build": "node_modules/.bin/gulp",
-    "build-docs": "./scripts/build-docs.sh",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "about": "node scripts/about.js",
-    "postinstall": "npm run build",
-    "preversion": "npm run lint",
+    "lint": "jshint src package.json gulpfile.js",
+
+    "build": "gulp",
+    "docs": "gulp doc",
+
+    "pretest": "npm run lint",
+    "test": "karma start --single-run --browsers PhantomJS",
+    "watch:test": "karma start",
+
+    "preversion": "npm test",
     "version": "npm run build",
-    "postversion": "rm -rf build/temp"
+    "postversion": "rm -rf build/temp",
+
+    "postinstall": "npm run build",
+
+    "about": "node scripts/about.js"
   },
+  "pre-push": [
+    "lint", "test", "build"
+  ],
   "keywords": [
     "MyPureCloud",
     "PureCloud"
@@ -41,16 +51,26 @@
     "del": "^2.2.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
+    "gulp-jsdoc-to-markdown": "^1.2.2",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-uglify": "^1.5.3",
-    "gulp-jsdoc-to-markdown": "^1.2.2",
+    "gutil": "^1.6.4",
     "handlebars": "^4.0.5",
+    "jasmine": "^2.4.1",
     "jsdoc": "^3.4.0",
     "jshint": "*",
+    "karma": "^0.13.22",
+    "karma-browserify": "^5.0.5",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-jasmine": "^1.0.2",
+    "karma-phantomjs-launcher": "^1.0.0",
     "optimist": "^0.6.1",
+    "phantomjs-prebuilt": "^2.1.7",
+    "pre-push": "^0.1.1",
     "purecloud-api-sdk-common": "git://github.com/MyPureCloud/purecloud_api_sdk_common.git",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "watchify": "^3.7.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -19,3 +19,4 @@ exports.about = function () {
 
 exports.users = require('./modules/users');
 exports.alerting = require('./modules/alerting');
+exports.ui = require('./modules/ui');

--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -1,0 +1,29 @@
+/**
+ * Utilities for manipulating the PureCloud Client UI
+ * @module ui
+ * @since 1.0.0
+ */
+
+let comms = require('../utils/comms');
+
+/**
+ * Show the help UI.
+ * @since 1.0.0
+ *
+ * @example
+ * purecloud.apps.ui.showHelp();
+ */
+exports.showHelp = function () {
+    comms._sendMsgToPc('showHelp');
+};
+
+/**
+ * Hide the help UI.  Noop if already shown.
+ * @since 1.0.0
+ *
+ * @example
+ * purecloud.apps.ui.hideHelp();
+ */
+exports.hideHelp = function () {
+    comms._sendMsgToPc('hideHelp');
+};

--- a/src/utils/comms.js
+++ b/src/utils/comms.js
@@ -3,19 +3,19 @@ const ACTION_NAME_KEY = 'action';
 /**
  * @private
  */
-exports._postMsgToPc = function () {
+exports._postMsgToPc = function (msg, tgtOrigin, transfer, myWindow=window, myParent=parent, myConsole=console) {
     let validRuntime = false,
         validEnv = false,
         validApi = false;
 
-    if ((validRuntime = (typeof window === 'object' && typeof parent === 'object'))) {
-        if ((validEnv = parent !== window)) {
-            validApi = typeof parent.postMessage === 'function';
+    if ((validRuntime = (typeof myWindow === 'object' && typeof myParent === 'object'))) {
+        if ((validEnv = myParent !== myWindow)) {
+            validApi = typeof myParent.postMessage === 'function';
         }
     }
 
     if (validRuntime && validEnv && validApi) {
-        parent.postMessage(...arguments);
+        myParent.postMessage(msg, tgtOrigin, transfer);
     } else {
         let errMsg = 'PureCloud Communication Failed.  ';
         if (!validRuntime) {
@@ -26,8 +26,8 @@ exports._postMsgToPc = function () {
             errMsg += 'postMessage not supported in this browser.';
         }
 
-        if (console) {
-            console.error(errMsg);
+        if (myConsole) {
+            myConsole.error(errMsg);
         } else {
             throw new Error(errMsg);
         }
@@ -38,7 +38,10 @@ exports._postMsgToPc = function () {
  * @private
  */
 exports._sendMsgToPc = function (actionName, msgPayload) {
-    let postMsgPayload = JSON.parse(JSON.stringify(msgPayload));
+    let postMsgPayload = {};
+    if (msgPayload && typeof msgPayload === 'object') {
+        postMsgPayload = JSON.parse(JSON.stringify(msgPayload));
+    }
     postMsgPayload[ACTION_NAME_KEY] = actionName;
     exports._postMsgToPc(postMsgPayload, '*');
 };

--- a/src/utils/commsSpec.js
+++ b/src/utils/commsSpec.js
@@ -1,0 +1,96 @@
+let commsUtil = require('./comms');
+
+module.exports = describe('comms util', () => {
+    it('should have the correct signature', function () {
+        expect(typeof commsUtil._postMsgToPc).toBe('function');
+        expect(typeof commsUtil._sendMsgToPc).toBe('function');
+    });
+
+    it('should allow sending simple messages to PC', () => {
+        spyOn(commsUtil, '_postMsgToPc');
+
+        commsUtil._sendMsgToPc('mySimpleCommand');
+
+        expect(commsUtil._postMsgToPc).toHaveBeenCalledWith({action: 'mySimpleCommand'}, '*');
+    });
+
+    it('should allow sending messages with options to PC', () => {
+        spyOn(commsUtil, '_postMsgToPc');
+
+        commsUtil._sendMsgToPc('myTestCommand', {foo: 1});
+
+        expect(commsUtil._postMsgToPc).toHaveBeenCalledWith({action: 'myTestCommand', foo: 1}, '*');
+    });
+
+    it('should not leak internals into user space', () => {
+        spyOn(commsUtil, '_postMsgToPc');
+
+        let cmdOptions = {foo: 1};
+
+        commsUtil._sendMsgToPc('myTestCommand', cmdOptions);
+
+        expect(commsUtil._postMsgToPc).toHaveBeenCalledWith({action: 'myTestCommand', foo: 1}, '*');
+        expect(cmdOptions.action).toBe(undefined);
+    });
+
+    it('should not work without a window instance', () => {
+        expect(() => {
+            commsUtil._postMsgToPc('message', '*', undefined, null, {}, null);
+        }).toThrowError();
+    });
+
+    it('should not work outside of an iframe', () => {
+        let myWindow, myParent;
+        myWindow = myParent = {
+            postMessage() {
+                return null;
+            }
+        };
+
+        expect(() => {
+            commsUtil._postMsgToPc('message', '*', undefined, myWindow, myParent, null);
+        }).toThrowError();
+    });
+
+    it('should require the postMessage api', () => {
+        let myWindow, myParent;
+        myWindow = myParent = {};
+
+        expect(() => {
+            commsUtil._postMsgToPc('message', '*', undefined, myWindow, myParent, null);
+        }).toThrowError();
+    });
+
+    it('should use the console for errors if avaialable', () => {
+        let myWindow, myParent, myConsole;
+        myWindow = myParent = {};
+
+        myConsole = {
+            error() {
+                return null;
+            }
+        };
+
+        spyOn(myConsole, 'error');
+
+        commsUtil._postMsgToPc('message', '*', undefined, myWindow, myParent, myConsole);
+
+        expect(myConsole.error).toHaveBeenCalled();
+    });
+
+    it('should call postMessage when the env is right', () => {
+        let myWindow, myParent;
+        myWindow = {};
+        myParent = {
+            postMessage() {
+                return null;
+            }
+        };
+
+        spyOn(myParent, 'postMessage');
+
+        commsUtil._postMsgToPc('message', '*', undefined, myWindow, myParent);
+
+        expect(myParent.postMessage).toHaveBeenCalledWith('message', '*', undefined);
+    });
+});


### PR DESCRIPTION
Add new ui module:
    showHelp and hideHelp Commands
    Generate new docs for ui module

Enhancement:
    Add support for simple, message-only messages

Tooling:
    Add pre-push hooks
    Require test (and lint) for a NPM version call

```
Unit Testing:
    Add karma (PhantomJS and Chrome) and jasmine

    Update NPM Scripts:
        Add test and pretest npm scripts
        Make the default test script a single-run, headless test run
        Add watch:test script for easy development

    Add comms util unit tests
        Add Method level dep injection for easy comms util mocking
```

Misc:
    Add README development and contributing sections
    Add missing deps to package.json
    Clean up some linting errors
    Add additional resources to linting
    Fix build and docs npm scripts
    Add build-browser dep to doc gulp task
    Reorder npm scripts conceptually and in workflow order
