### PR TITLE
Make deployed examples backwards compatible

### DIFF
--- a/examples/help.html
+++ b/examples/help.html
@@ -56,7 +56,19 @@
 
         <script>
             $(function () {
-                let myClientApp = new window.purecloud.apps.ClientApp({pcEnvironmentQueryParam: 'pcEnvironment'});
+                let myClientApp = null;
+
+                // Note: This manual check for query string is for backwards compatibility of this
+                // deployed example.  In your own apps, you can assume the query param will be
+                // provided by PureCloud if you have configured it in your app's config.
+                let envQueryParamName = 'pcEnvironment';
+                if (window && window.location && typeof window.location.search === 'string' &&
+                    window.location.search.indexOf(envQueryParamName) >= 0) {
+                    myClientApp = new window.purecloud.apps.ClientApp({pcEnvironmentQueryParam: envQueryParamName});
+                } else {
+                    // Use default PureCloud region
+                    myClientApp = new window.purecloud.apps.ClientApp();
+                }
 
                 function showResourceCenterArtifact(relPath) {
                     myClientApp.coreUi.showResourceCenterArtifact(relPath);

--- a/examples/lifecycleDemo.html
+++ b/examples/lifecycleDemo.html
@@ -116,7 +116,19 @@
             var lifecycleStatusMessageId = 'lifecycleDemo-statusMsg';
 
             jQuery(function () {
-                let myClientApp = new window.purecloud.apps.ClientApp({pcEnvironmentQueryParam: 'pcEnvironment'});
+                let myClientApp = null;
+
+                // Note: This manual check for query string is for backwards compatibility of this
+                // deployed example.  In your own apps, you can assume the query param will be
+                // provided by PureCloud if you have configured it in your app's config.
+                let envQueryParamName = 'pcEnvironment';
+                if (window && window.location && typeof window.location.search === 'string' &&
+                    window.location.search.indexOf(envQueryParamName) >= 0) {
+                    myClientApp = new window.purecloud.apps.ClientApp({pcEnvironmentQueryParam: envQueryParamName});
+                } else {
+                    // Use default PureCloud region
+                    myClientApp = new window.purecloud.apps.ClientApp();
+                }
 
                 $window = jQuery(window);
 

--- a/examples/toast.html
+++ b/examples/toast.html
@@ -140,7 +140,19 @@
         </div>
 
         <script>$(function () {
-                let myClientApp = new window.purecloud.apps.ClientApp({pcEnvironmentQueryParam: 'pcEnvironment'});
+                let myClientApp = null;
+
+                // Note: This manual check for query string is for backwards compatibility of this
+                // deployed example.  In your own apps, you can assume the query param will be
+                // provided by PureCloud if you have configured it in your app's config.
+                let envQueryParamName = 'pcEnvironment';
+                if (window && window.location && typeof window.location.search === 'string' &&
+                    window.location.search.indexOf(envQueryParamName) >= 0) {
+                    myClientApp = new window.purecloud.apps.ClientApp({pcEnvironmentQueryParam: envQueryParamName});
+                } else {
+                    // Use default PureCloud region
+                    myClientApp = new window.purecloud.apps.ClientApp();
+                }
 
                 // Toast
                 var $titleField = $('input#title');


### PR DESCRIPTION
Fall back to the default PureCloud environment if no environment has been provided to the app examples via the query string.  This will allow previously configured apps to still work in the default region.