### PR TITLE
Add lifecycle event listeners {{READY_FOR_REVIEW}}

### DIFF
--- a/src/modules/base.js
+++ b/src/modules/base.js
@@ -48,6 +48,27 @@ class BaseApi {
          * @ignore
          */
         this._commsUtils = commsUtils;
+
+        // ----- Message Listening
+
+        this._msgListenerCfgs = {};
+        this._msgHandler = this._onMsg.bind(this);
+
+        /**
+         * Injection point for tests.  Should not be used by api users or extenders.
+         *
+         * @private
+         * @ignore
+         */
+        this._myWindow = window;
+
+        /**
+         * Injection point for tests.  Should not be used by api users or extenders.
+         *
+         * @private
+         * @ignore
+         */
+        this._myParent = (window ? window.parent : undefined);
     }
 
     /**
@@ -58,7 +79,7 @@ class BaseApi {
      * @param {object} msgPayload
      *
      * @package
-     * @ignore
+     * @ignore Extender-use only.  Not a public API
      *
      * @since 1.0.0
      */
@@ -76,7 +97,7 @@ class BaseApi {
      * @returns {object} A postMessage payload for the Client Apps SDK
      *
      * @package
-     * @ignore
+     * @ignore Extender-use only.  Not a public API
      *
      * @since 1.0.0
      */
@@ -95,6 +116,269 @@ class BaseApi {
         result[PROTOCOL_AGENT_VERSION_KEY] = this._protocolDetails.agentVersion;
 
         return result;
+    }
+
+    // ----- Message Listening
+
+    /**
+     * Adds the specified listener to messages sent from the host PureCloud appliation
+     * on the specified eventType
+     *
+     * @param {string} eventType - The name of the purecloudEventType in the message; case and leading/trailing space sensitive
+     * @param {function} listener - The listener function to invoke when a message of the specified eventType
+     *   is received.  Message data will be passed
+     * @param {object} options - Options for the invocation of the listener; null/undefined will use defaults
+     * @param {boolean} options.once - Set to true to only invoke this listener once; it will be removed after first invocation.
+     *  false by default.  null/undefined will use default.
+     * @param {boolean} options.msgPayloadFilter - Provide a function to further filter the invocation of the listener;
+     *  The listener will be called if this method returns a truthy value. null by default.  undefined will also use default.
+     *
+     * @since 1.0.0
+     * @ignore Extender-use only.  Not a public API
+     */
+    addMsgListener(eventType, listener, options = {}) {
+        if (!eventType || typeof eventType !== 'string' || eventType.trim().length === 0) {
+            throw new Error('Invalid eventType provided to addMsgListener');
+        }
+
+        if (!listener || typeof listener !== 'function') {
+            throw new Error('Invalid listener provided to addMsgListener');
+        }
+
+        let proposedListenerCfg = {
+            listener,
+            options: this._buildNormalizedListenerOptions(options)
+        };
+
+        let duplicateListener = false;
+        let listenerCfgs = this._msgListenerCfgs[eventType];
+        if (!listenerCfgs) {
+            listenerCfgs = [];
+            this._msgListenerCfgs[eventType] = listenerCfgs;
+        } else if (listenerCfgs.length > 0) {
+            // Check for duplicates
+            listenerCfgs.forEach(currListenerCfg => {
+                if (this._isDuplicateListenerCfg(currListenerCfg, proposedListenerCfg)) {
+                    duplicateListener = true;
+                }
+            });
+        }
+
+        if (!duplicateListener) {
+            listenerCfgs.push(proposedListenerCfg);
+
+            if (this._getListenerCount() === 1) {
+                // This is the addition of the only active listener, start listening
+                this._subscribeToMsgs();
+            }
+        }
+    }
+
+    /**
+     * Removes the specified listener from messages sent from the host PureCloud appliation
+     * on the specified eventType. eventType, listener (strict equality), and options must match.
+     *
+     * @param {string} eventType - The name of the purecloudEventType previously registered; case and leading/trailing space sensitive
+     * @param {function} listener - The exact listener function instance that was previously registered.
+     * @param {object} options - Options registered with the listener;
+     *  null and undefined trigger defaults and will be considered equal.
+     * @param {boolean} options.once - Set as true if once was explicitly set as true when adding the listener;
+     *  otherwise, you can explicitly provide false or rely on the default.
+     * @param {function} options.msgPayloadFilter - Provide the same function instance provided when adding the listener;
+     *  otherwise, you can rely on the empty default by either not specifing a function or providing null/undefined.
+     *
+     * @returns undefined
+     *
+     * @throws Error if the eventType, listener, or options are invalid
+     *
+     * @since 1.0.0
+     * @ignore Extender-use only.  Not a public API
+     */
+    removeMsgListener(eventType, listener, options = {}) {
+        if (!eventType || typeof eventType !== 'string' || eventType.trim().length === 0) {
+            throw new Error('Invalid eventType provided to removeMsgListener');
+        }
+
+        if (!listener || typeof listener !== 'function') {
+            throw new Error('Invalid listener provided to removeMsgListener');
+        }
+
+        // Note: Building the normalized options also validates the options param.
+        // This should stay here to always validate the params regardless of eventType listener presence
+        let listenerCfgToRemove = {
+            listener,
+            options: this._buildNormalizedListenerOptions(options)
+        };
+
+        let eventTypeListenerCfgs = this._msgListenerCfgs[eventType];
+        if (eventTypeListenerCfgs) {
+            let listenerCfgIndex = -1;
+            for (let index = 0; index < eventTypeListenerCfgs.length; index++) {
+                if (this._isDuplicateListenerCfg(eventTypeListenerCfgs[index], listenerCfgToRemove)) {
+                    listenerCfgIndex = index;
+                    break;
+                }
+            }
+
+            if (listenerCfgIndex >= 0) {
+                eventTypeListenerCfgs.splice(listenerCfgIndex, 1);
+
+                if (this._getListenerCount() === 0) {
+                    // No more listeners, tear down our listener
+                    this._unsubscribeFromMsgs();
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the total number of registered listeners.
+     *
+     * @private
+     * @ignore
+     */
+    _getListenerCount() {
+        let result = 0;
+
+        Object.keys(this._msgListenerCfgs).forEach(currEventType => {
+            let currListenerCfgs = this._msgListenerCfgs[currEventType];
+
+            if (currListenerCfgs) {
+                result += currListenerCfgs.length;
+            }
+        });
+
+        return result;
+    }
+
+    /**
+     * Intiate listening for messages from the host PureCloud application
+     *
+     * @private
+     * @ignore
+     */
+    _subscribeToMsgs() {
+        this._myWindow.addEventListener('message', this._msgHandler);
+    }
+
+    /**
+     * Stop listening for messages from the host PureCloud application
+     *
+     * @private
+     * @ignore
+     */
+    _unsubscribeFromMsgs() {
+        this._myWindow.removeEventListener('message', this._msgHandler);
+    }
+
+    /**
+     * Message handler function that will filter message events and invoke the correct, registered
+     * listeners.
+     *
+     * @private
+     * @ignore
+     */
+    _onMsg(event) {
+        if (!event || !event.source || !event.origin || event.source !== this._myParent ||
+            event.origin !== this._targetPcOrigin || !event.data || typeof event.data !== 'object' ||
+            Array.isArray(event.data)) {
+            // Fast-fail for invalid or unknown event
+            return;
+        }
+
+        // Validate base payload
+        let eventType = event.data.purecloudEventType;
+        if (eventType && typeof eventType === 'string' && eventType.trim()) {
+            let eventTypeListenerCfgs = this._msgListenerCfgs[eventType];
+            if (eventTypeListenerCfgs && eventTypeListenerCfgs.length > 0) {
+                let listenerCfgsToRemove = [];
+
+                eventTypeListenerCfgs.forEach(currListenerCfg => {
+                    if (!currListenerCfg.options.msgPayloadFilter || currListenerCfg.options.msgPayloadFilter(event.data)) {
+                        // Clone the event data and prune internal props before sending the event to user-space
+                        let userSpaceEventData = JSON.parse(JSON.stringify(event.data));
+                        delete userSpaceEventData[PROTOCOL_NAME_KEY];
+
+                        currListenerCfg.listener(userSpaceEventData);
+
+                        if (currListenerCfg.options.once) {
+                            listenerCfgsToRemove.push(currListenerCfg);
+                        }
+                    }
+                });
+
+                if (listenerCfgsToRemove.length > 0) {
+                    listenerCfgsToRemove.forEach(currListenerCfg => {
+                        this.removeMsgListener(eventType, currListenerCfg.listener, currListenerCfg.options);
+                    });
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates and normalizes listener options. msgPayloadFilter will be normalized to null and once
+     * will be normalized to false if not specified or specified as an "empty" object (null/undefined).
+     *
+     * @param {object} options The additional options config provided to [add|remove]MsgListener; null and undefined also allowed.
+     * @param {function} options.msgPayloadFilter An additional filtering function; null and undefined also allowed.
+     * @param {boolean} options.once A boolean indicating if the listener should be removed after first fire; null and undefined also allowed.
+     *
+     * @returns A normalized listener options object containing the msgPayloadFilter and once properties.
+     * msgPayloadFilter will be null unless a valid function is explicitly provided.  once will be false unless true
+     * is explictly provided.
+     *
+     * @throws Error if options is not null, undefined, or an object
+     * @throws Error if options.msgPayloadFilter is not null, undefined, or a function
+     * @throws Error if options.once is not null, undefined, or a boolean
+     *
+     * @private
+     * @ignore
+     */
+    _buildNormalizedListenerOptions(options) {
+        let result = {
+            msgPayloadFilter: null,
+            once: false
+        };
+
+        if (options === null || options === undefined) {
+            return result;
+        }
+
+        if (typeof options !== 'object' || Array.isArray(options)) {
+            throw new Error('Invalid options provided');
+        }
+
+        let filter = options.msgPayloadFilter;
+        if (filter !== null && filter !== undefined && typeof filter !== 'function') {
+            throw new Error('options.msgPayloadFilter must be a function if specified');
+        }
+        result.msgPayloadFilter = filter || null;
+
+        if (options.once !== null && options.once !== undefined && typeof options.once !== 'boolean') {
+            throw new Error('options.once must be a boolean if specified');
+        }
+        result.once = options.once || false;
+
+        return result;
+    }
+
+    /**
+     * Determines if the specified listener configs are duplicates with respect to
+     * listener registration.  Assumes the configs will be normalized for easier comparison.
+     *
+     * @param {object} listenerCfg1 The first config
+     * @param {object} listenerCfg2 The second config
+     *
+     * @returns true if the listener, msgPayloadFilter, and once are equal; false otherwise
+     *
+     * @private
+     * @ignore
+     */
+    _isDuplicateListenerCfg(listenerCfg1, listenerCfg2) {
+        return (listenerCfg1.listener === listenerCfg2.listener &&
+            listenerCfg1.options.once === listenerCfg2.options.once &&
+            listenerCfg1.options.msgPayloadFilter === listenerCfg2.options.msgPayloadFilter);
     }
 }
 

--- a/src/modules/baseSpec.js
+++ b/src/modules/baseSpec.js
@@ -2,6 +2,8 @@
 import BaseApi from './base';
 import {name as pkgName, version as pkgVersion} from '../../package.json';
 
+const APPS_API_PROTOCOL = 'purecloud-client-apps';
+
 export default describe('BaseApi', () => {
     const baseProtoDetails = {
         protocol: 'foo',
@@ -84,5 +86,785 @@ export default describe('BaseApi', () => {
         expect(args.length).toBe(2);
         expect(args[0]).toEqual(Object.assign({}, {action}, baseProtoDetails, actionPayload));
         expect(args[1]).toBe(targetPcOrigin);
+    });
+
+    describe('MessageListeners', () => {
+        let targetPcOrigin = 'https://subdomain.envdomain.com';
+        let baseApi = null;
+
+        beforeEach(function () {
+            baseApi = new BaseApi(Object.assign({}, {targetPcOrigin}, baseProtoDetails));
+        });
+
+        describe('addMsgListener', () => {
+            it('should validate it\'s params', () => {
+                // Invalid Event Types
+                [null, undefined, 1, [], {}, '', ' ', true].forEach(currEventType => {
+                    expect(() => {
+                        baseApi.addMsgListener(currEventType, () => {});
+                    }).toThrowError(/^Invalid eventType.*$/);
+                });
+
+                // Invalid listeners
+                [null, undefined, 1, [], {}, '', ' ', true].forEach(currListener => {
+                    expect(() => {
+                        baseApi.addMsgListener('foo', currListener);
+                    }).toThrowError(/^Invalid listener.*$/);
+                });
+
+                // Invalid options
+                [1, [], '', ' ', true, () => {}].forEach(currOptions => {
+                    expect(() => {
+                        baseApi.addMsgListener('foo', () => {}, currOptions);
+                    }).toThrowError(/^Invalid options.*$/);
+                });
+
+                // Valid options
+                [null, undefined, {}].forEach(currOptions => {
+                    expect(() => {
+                        baseApi.addMsgListener('foo', () => {}, currOptions);
+                    }).not.toThrow();
+                });
+
+                // Invalid msgPayloadFilter options
+                [1, [], {}, '', ' ', true].forEach(currFilter => {
+                    expect(() => {
+                        baseApi.addMsgListener('foo', () => {}, {msgPayloadFilter: currFilter});
+                    }).toThrowError(/^.*msgPayloadFilter.*$/);
+                });
+
+                // Valid msgPayloadFilter options
+                [null, undefined, () => {}].forEach(currFilter => {
+                    expect(() => {
+                        baseApi.addMsgListener('foo', () => {}, {msgPayloadFilter: currFilter});
+                    }).not.toThrow();
+                });
+                expect(() => {
+                    baseApi.addMsgListener('foo', () => {}, {noFilterKey: 'provided'});
+                }).not.toThrow();
+
+                // Invalid once options
+                [1, [], {}, '', ' ', () => {}].forEach(currOnce => {
+                    expect(() => {
+                        baseApi.addMsgListener('foo', () => {}, {once: currOnce});
+                    }).toThrowError(/^.*once.*$/);
+                });
+
+                // Valid once options
+                [null, undefined, true, false].forEach(currOnce => {
+                    expect(() => {
+                        baseApi.addMsgListener('foo', () => {}, {once: currOnce});
+                    }).not.toThrow();
+                });
+                expect(() => {
+                    baseApi.addMsgListener('foo', () => {}, {noOnceKey: 'provided'});
+                }).not.toThrow();
+            });
+
+            it('should allow multiple distinct listeners per event', () => {
+                expect(baseApi._getListenerCount()).toBe(0);
+                baseApi.addMsgListener('event1', () => {});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.addMsgListener('event1', () => {});
+                expect(baseApi._getListenerCount()).toBe(2);
+            });
+
+            it('should not attach duplicate listeners', () => {
+                expect(baseApi._getListenerCount()).toBe(0);
+                let myListener = () => {};
+                baseApi.addMsgListener('event1', myListener);
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.addMsgListener('event1', myListener);
+                expect(baseApi._getListenerCount()).toBe(1);
+
+                // But, the same listener instance can be attached to multiple events
+                baseApi.addMsgListener('event2', myListener);
+                expect(baseApi._getListenerCount()).toBe(2);
+            });
+
+            it('should treat eventTypes as case and space sensitive', () => {
+                let eventType = 'CaSeSeNsItIvE';
+
+                expect(baseApi._getListenerCount()).toBe(0);
+                let myListener = () => {};
+                baseApi.addMsgListener(eventType, myListener);
+                expect(baseApi._getListenerCount()).toBe(1);
+
+                // Space Sensitive
+                baseApi.addMsgListener(` ${eventType}`, myListener);
+                expect(baseApi._getListenerCount()).toBe(2);
+                baseApi.addMsgListener(`${eventType} `, myListener);
+                expect(baseApi._getListenerCount()).toBe(3);
+                baseApi.addMsgListener(` ${eventType} `, myListener);
+                expect(baseApi._getListenerCount()).toBe(4);
+
+                // Case Sensitive
+                baseApi.addMsgListener(eventType.toUpperCase(), myListener);
+                expect(baseApi._getListenerCount()).toBe(5);
+            });
+
+            it('should treat empty options as defaults in the listener options uniqueness check', () => {
+                [null, undefined, {}].forEach(defaultOptionEquivalent => {
+                    let myListener = () => {};
+
+                    baseApi.addMsgListener('foo', myListener);
+                    expect(baseApi._getListenerCount()).toBe(1);
+
+                    baseApi.addMsgListener('foo', myListener, defaultOptionEquivalent);
+                    expect(baseApi._getListenerCount()).toBe(1);
+
+                    // Remove it for next test
+                    baseApi.removeMsgListener('foo', myListener);
+                    expect(baseApi._getListenerCount()).toBe(0);
+                });
+            });
+
+            it('should include the msgPayloadFilter in the listener uniqueness check', () => {
+                let eventType = 'sameEventDiffFilter';
+
+                expect(baseApi._getListenerCount()).toBe(0);
+                let myListener = () => {};
+                baseApi.addMsgListener(eventType, myListener);
+                expect(baseApi._getListenerCount()).toBe(1);
+
+                // Null or undefined filters should use default and be considered the same
+                baseApi.addMsgListener(eventType, myListener, {noFilterKey: 'provided'});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.addMsgListener(eventType, myListener, {msgPayloadFilter: null});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.addMsgListener(eventType, myListener, {msgPayloadFilter: undefined});
+                expect(baseApi._getListenerCount()).toBe(1);
+
+                // A listener with a different payload should be considered unique
+                let myFilter = () => {};
+                baseApi.addMsgListener(eventType, myListener, {msgPayloadFilter: myFilter});
+                expect(baseApi._getListenerCount()).toBe(2);
+
+                // The same filter should collide
+                baseApi.addMsgListener(eventType, myListener, {msgPayloadFilter: myFilter});
+                expect(baseApi._getListenerCount()).toBe(2);
+            });
+
+            it('should include the once setting in the listener uniqueness check', () => {
+                let eventType = 'sameEventDiffOnce';
+
+                expect(baseApi._getListenerCount()).toBe(0);
+                let myListener = () => {};
+                baseApi.addMsgListener(eventType, myListener);
+                expect(baseApi._getListenerCount()).toBe(1);
+
+                // The default once is false; null and undefined should also use the default
+                baseApi.addMsgListener(eventType, myListener, {noOnceKey: 'provided'});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.addMsgListener(eventType, myListener, {once: null});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.addMsgListener(eventType, myListener, {once: undefined});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.addMsgListener(eventType, myListener, {once: false});
+                expect(baseApi._getListenerCount()).toBe(1);
+
+                // A different once should be considered a unique listener
+                baseApi.addMsgListener(eventType, myListener, {once: true});
+                expect(baseApi._getListenerCount()).toBe(2);
+
+                // The same once should collide
+                baseApi.addMsgListener(eventType, myListener, {once: true});
+                expect(baseApi._getListenerCount()).toBe(2);
+            });
+
+            it('should include all options at once in the listener uniqueness check', () => {
+                let eventType = 'sameEvent';
+
+                expect(baseApi._getListenerCount()).toBe(0);
+                let myListener = () => {};
+                let myFilter = () => {};
+                baseApi.addMsgListener(eventType, myListener, {once: true, msgPayloadFilter: myFilter});
+                expect(baseApi._getListenerCount()).toBe(1);
+
+                baseApi.addMsgListener(eventType, myListener, {once: true, msgPayloadFilter: () => {}});
+                expect(baseApi._getListenerCount()).toBe(2);
+                baseApi.addMsgListener(eventType, myListener, {once: false, msgPayloadFilter: myFilter});
+                expect(baseApi._getListenerCount()).toBe(3);
+
+                // The same options should collide
+                baseApi.addMsgListener(eventType, myListener, {once: true, msgPayloadFilter: myFilter});
+                expect(baseApi._getListenerCount()).toBe(3);
+            });
+
+            it('should start listening for events when the first listener is added', () => {
+                let mockWindow = {
+                    addEventListener() {}
+                };
+                baseApi._myWindow = mockWindow;
+
+                spyOn(mockWindow, 'addEventListener');
+
+                baseApi.addMsgListener('foo', () => {});
+                expect(mockWindow.addEventListener).toHaveBeenCalledTimes(1);
+                expect(mockWindow.addEventListener.calls.mostRecent().args[0]).toBe('message');
+                expect(typeof mockWindow.addEventListener.calls.mostRecent().args[1]).toBe('function');
+
+                // Should not reattach the listener
+                baseApi.addMsgListener('foo', () => {});
+                baseApi.addMsgListener('bar', () => {});
+                expect(mockWindow.addEventListener).toHaveBeenCalledTimes(1);
+            });
+        });
+
+        describe('invokingListeners', () => {
+            let eventType = 'anEvent';
+            let basePayloadData = {
+                protocol: APPS_API_PROTOCOL,
+                purecloudEventType: eventType
+            };
+            let fireEvent = null;
+            let mockParent;
+            let mockWindow;
+
+            beforeEach(() => {
+                mockParent = {};
+                mockWindow = {
+                    addEventListener() {},
+                    removeEventListener() {}
+                };
+                baseApi._myWindow = mockWindow;
+                baseApi._myParent = mockParent;
+
+                fireEvent = function () {
+                    baseApi._onMsg(...arguments);
+                };
+            });
+
+            it('should validate the incoming message as PC genuine', () => {
+                let myObj = {
+                    myListener(data) {}
+                };
+                spyOn(myObj, 'myListener').and.callThrough();
+
+                baseApi.addMsgListener(eventType, myObj.myListener);
+
+                fireEvent({
+                    source: mockParent,
+                    origin: targetPcOrigin,
+                    data: basePayloadData
+                });
+
+                expect(myObj.myListener).toHaveBeenCalledTimes(1);
+
+                // Missing or invalid event
+                fireEvent();
+                let invalidEventCases = [
+                    null, undefined, {}, [], '', ' ', 1
+                ];
+                invalidEventCases.forEach(currCase => {
+                    fireEvent(currCase);
+                });
+
+                // Missing or invalid source
+                fireEvent({
+                    origin: targetPcOrigin,
+                    data: basePayloadData
+                });
+                let invalidSourceCases = [
+                    null, undefined, {}
+                ];
+                invalidSourceCases.forEach(currCase => {
+                    fireEvent({
+                        source: currCase,
+                        origin: targetPcOrigin,
+                        data: basePayloadData
+                    });
+                });
+
+                // Missing or invalid origins
+                fireEvent({
+                    source: mockParent,
+                    data: basePayloadData
+                });
+                let invalidOriginCases = [
+                    null, undefined, 'null',
+                    'http://subdomain.envdomain.com',
+                    'https://envdomain.com',
+                    'https://subdomain.anotherdomain.com',
+                    'https://subdomain.envdomain.com:443', // Default protocol port is implied
+                    'https://subdomain.anotherdomain.com/path'
+                ];
+                invalidOriginCases.forEach(currCase => {
+                    fireEvent({
+                        source: mockParent,
+                        origin: currCase,
+                        data: basePayloadData
+                    });
+                });
+
+                // Missing or invalid data cases
+                fireEvent({
+                    source: mockParent,
+                    origin: targetPcOrigin
+                });
+                let invalidDataCases = [
+                    null, undefined, 1, '', ' ', true, [], {}, {
+                        purecloudEventType: null
+                    }, {
+                        purecloudEventType: undefined
+                    }, {
+                        purecloudEventType: ''
+                    }, {
+                        purecloudEventType: ' '
+                    }, {
+                        purecloudEventType: {}
+                    }, {
+                        purecloudEventType: []
+                    }
+                ];
+                invalidDataCases.forEach(currCase => {
+                    fireEvent({
+                        source: mockParent,
+                        origin: targetPcOrigin,
+                        data: currCase
+                    });
+                });
+
+                // None of the above should cause the listener to be fired
+                expect(myObj.myListener).toHaveBeenCalledTimes(1);
+            });
+
+            it('should only invoke the listener when receiving the specified event type', () => {
+                let myObj = {
+                    myListener: () => {}
+                };
+                spyOn(myObj, 'myListener');
+
+                baseApi.addMsgListener(eventType, myObj.myListener);
+                baseApi.addMsgListener('foo', myObj.myListener);
+
+                fireEvent({
+                    source: mockParent,
+                    origin: targetPcOrigin,
+                    data: Object.assign({}, basePayloadData, {purecloudEventType: eventType})
+                });
+
+                expect(myObj.myListener).toHaveBeenCalledTimes(1);
+
+                // Leading and trailing spaces are part of the key; should not be called
+                fireEvent({
+                    source: mockParent,
+                    origin: targetPcOrigin,
+                    data: Object.assign({}, basePayloadData, {purecloudEventType: ` ${eventType} `})
+                });
+                expect(myObj.myListener).toHaveBeenCalledTimes(1);
+
+                // events are case sensitive; should not be called
+                fireEvent({
+                    source: mockParent,
+                    origin: targetPcOrigin,
+                    data: Object.assign({}, basePayloadData, {purecloudEventType: eventType.toUpperCase()})
+                });
+                expect(myObj.myListener).toHaveBeenCalledTimes(1);
+            });
+
+            it('should pass user-space event data to the listeners', () => {
+                let myObj = {
+                    myListener: () => {}
+                };
+                spyOn(myObj, 'myListener');
+
+                baseApi.addMsgListener(eventType, myObj.myListener);
+
+                let origEventData = Object.assign({}, basePayloadData);
+                fireEvent({
+                    source: mockParent,
+                    origin: targetPcOrigin,
+                    data: origEventData
+                });
+
+                expect(myObj.myListener).toHaveBeenCalledTimes(1);
+                let eventPayload = myObj.myListener.calls.mostRecent().args[0];
+                let eventKeys = Object.keys(eventPayload);
+
+                // it should clone the original event data
+                expect(eventPayload).not.toBe(origEventData);
+                // it should not modify the original event data
+                expect(origEventData).toEqual(basePayloadData);
+
+                // it should remove internal props (protocol)
+                // the eventType might be useful for listeners and is consistent with browser listener api
+                expect(eventKeys.length).toBe(1);
+                expect(eventKeys[0]).toBe('purecloudEventType');
+                expect(eventPayload.purecloudEventType).toBe(eventType);
+
+                fireEvent({
+                    source: mockParent,
+                    origin: targetPcOrigin,
+                    data: Object.assign({}, basePayloadData, {
+                        additionalKey1: 'foo',
+                        additionalKey2: 'bar'
+                    })
+                });
+
+                expect(myObj.myListener).toHaveBeenCalledTimes(2);
+                eventPayload = myObj.myListener.calls.mostRecent().args[0];
+                eventKeys = Object.keys(eventPayload);
+                expect(eventKeys.length).toBe(3);
+                expect(eventPayload.purecloudEventType).toBe(eventType);
+                expect(eventPayload.additionalKey1).toBe('foo');
+                expect(eventPayload.additionalKey2).toBe('bar');
+            });
+
+            it('should only call the listener if a specified msgPayloadFilter passes', () => {
+                let listenerCallCount = 0;
+                let myObj = {
+                    myListener: () => {}
+                };
+                spyOn(myObj, 'myListener');
+
+                baseApi.addMsgListener(eventType, myObj.myListener, {msgPayloadFilter: () => {
+                    listenerCallCount++;
+                    return listenerCallCount > 1;
+                }});
+
+                let event = {
+                    source: mockParent,
+                    origin: targetPcOrigin,
+                    data: Object.assign({}, basePayloadData)
+                };
+                fireEvent(event);
+                expect(myObj.myListener).toHaveBeenCalledTimes(0);
+                fireEvent(event);
+                expect(myObj.myListener).toHaveBeenCalledTimes(1);
+                fireEvent(event);
+                expect(myObj.myListener).toHaveBeenCalledTimes(2);
+            });
+
+            it('should call the listener multiple times if once is false', () => {
+                let myObj = {
+                    myListener: () => {},
+                    myListenerWithFilter: () => {},
+                    myListenerWithDefaultOnce: () => {}
+                };
+                spyOn(myObj, 'myListener');
+                spyOn(myObj, 'myListenerWithFilter');
+                spyOn(myObj, 'myListenerWithDefaultOnce');
+
+                baseApi.addMsgListener(eventType, myObj.myListener, {once: false});
+                baseApi.addMsgListener(eventType, myObj.myListenerWithFilter, {once: false, msgPayloadFilter: () => true});
+                baseApi.addMsgListener(eventType, myObj.myListenerWithDefaultOnce);
+
+                let event = {
+                    source: mockParent,
+                    origin: targetPcOrigin,
+                    data: Object.assign({}, basePayloadData)
+                };
+                fireEvent(event);
+                expect(myObj.myListener).toHaveBeenCalledTimes(1);
+                expect(myObj.myListenerWithFilter).toHaveBeenCalledTimes(1);
+                expect(myObj.myListenerWithDefaultOnce).toHaveBeenCalledTimes(1);
+                fireEvent(event);
+                expect(baseApi._getListenerCount()).toBe(3);
+                expect(myObj.myListener).toHaveBeenCalledTimes(2);
+                expect(myObj.myListenerWithFilter).toHaveBeenCalledTimes(2);
+                expect(myObj.myListenerWithDefaultOnce).toHaveBeenCalledTimes(2);
+            });
+
+            it('should only call the listener once if so configured', () => {
+                let myObj = {
+                    myListener: () => {},
+                    myListenerWithFilter: () => {}
+                };
+                spyOn(myObj, 'myListener');
+                spyOn(myObj, 'myListenerWithFilter');
+
+                baseApi.addMsgListener(eventType, myObj.myListener, {once: true});
+                baseApi.addMsgListener(eventType, myObj.myListenerWithFilter, {once: true, msgPayloadFilter: () => true});
+
+                let event = {
+                    source: mockParent,
+                    origin: targetPcOrigin,
+                    data: Object.assign({}, basePayloadData)
+                };
+                fireEvent(event);
+                expect(myObj.myListener).toHaveBeenCalledTimes(1);
+                expect(myObj.myListenerWithFilter).toHaveBeenCalledTimes(1);
+                expect(baseApi._getListenerCount()).toBe(0);
+                fireEvent(event);
+                expect(myObj.myListener).toHaveBeenCalledTimes(1);
+                expect(myObj.myListenerWithFilter).toHaveBeenCalledTimes(1);
+            });
+
+            it('should be able to remove multiple once listeners per event', () => {
+                let myObj = {
+                    myListener: () => {},
+                    myListener2: () => {}
+                };
+                spyOn(myObj, 'myListener');
+                spyOn(myObj, 'myListener2');
+
+                baseApi.addMsgListener(eventType, myObj.myListener, {once: true});
+                baseApi.addMsgListener(eventType, myObj.myListener2, {once: true});
+                expect(baseApi._getListenerCount()).toBe(2);
+
+                let event = {
+                    source: mockParent,
+                    origin: targetPcOrigin,
+                    data: Object.assign({}, basePayloadData)
+                };
+                fireEvent(event);
+                expect(myObj.myListener).toHaveBeenCalledTimes(1);
+                expect(myObj.myListener2).toHaveBeenCalledTimes(1);
+                fireEvent(event);
+                expect(baseApi._getListenerCount()).toBe(0);
+                expect(myObj.myListener).toHaveBeenCalledTimes(1);
+                expect(myObj.myListener2).toHaveBeenCalledTimes(1);
+            });
+        });
+
+        describe('removeMsgListener', () => {
+            it('should validate it\'s params', () => {
+                // Invalid Event Types
+                [null, undefined, 1, [], {}, '', ' ', true].forEach(currEventType => {
+                    expect(() => {
+                        baseApi.removeMsgListener(currEventType, () => {});
+                    }).toThrowError(/^Invalid eventType.*$/);
+                });
+
+                // Invalid listeners
+                [null, undefined, 1, [], {}, '', ' ', true].forEach(currListener => {
+                    expect(() => {
+                        baseApi.removeMsgListener('foo', currListener);
+                    }).toThrowError(/^Invalid listener.*$/);
+                });
+
+                // Invalid options
+                [1, [], '', ' ', true, () => {}].forEach(currOptions => {
+                    expect(() => {
+                        baseApi.removeMsgListener('foo', () => {}, currOptions);
+                    }).toThrowError(/^Invalid options.*$/);
+                });
+
+                // Valid options
+                [null, undefined, {}].forEach(currOptions => {
+                    expect(() => {
+                        baseApi.removeMsgListener('foo', () => {}, currOptions);
+                    }).not.toThrow();
+                });
+
+                // Invalid msgPayloadFilter options
+                [1, [], {}, '', ' ', true].forEach(currFilter => {
+                    expect(() => {
+                        baseApi.removeMsgListener('foo', () => {}, {msgPayloadFilter: currFilter});
+                    }).toThrowError(/^.*msgPayloadFilter.*$/);
+                });
+
+                // Valid msgPayloadFilter options
+                [null, undefined, () => {}].forEach(currFilter => {
+                    expect(() => {
+                        baseApi.removeMsgListener('foo', () => {}, {msgPayloadFilter: currFilter});
+                    }).not.toThrow();
+                });
+                expect(() => {
+                    baseApi.removeMsgListener('foo', () => {}, {noFilterKey: 'provided'});
+                }).not.toThrow();
+
+                // Invalid once options
+                [1, [], {}, '', ' ', () => {}].forEach(currOnce => {
+                    expect(() => {
+                        baseApi.removeMsgListener('foo', () => {}, {once: currOnce});
+                    }).toThrowError(/^.*once.*$/);
+                });
+
+                // Valid once options
+                [null, undefined, true, false].forEach(currOnce => {
+                    expect(() => {
+                        baseApi.removeMsgListener('foo', () => {}, {once: currOnce});
+                    }).not.toThrow();
+                });
+                expect(() => {
+                    baseApi.removeMsgListener('foo', () => {}, {noOnceKey: 'provided'});
+                }).not.toThrow();
+            });
+
+            it('should remove the matching listener for the specified event type', () => {
+                let myListener = () => {};
+                baseApi.addMsgListener('foo', myListener);
+
+                expect(baseApi._getListenerCount()).toBe(1);
+                expect(baseApi.removeMsgListener('foo', myListener));
+                expect(baseApi._getListenerCount()).toBe(0);
+            });
+
+            it('should return silently if a matching eventType or listener is not found', () => {
+                // No listeners previously attached
+                expect(baseApi.removeMsgListener('foo', () => {})).toBe(undefined);
+
+                let myListener = () => {};
+                baseApi.addMsgListener('foo', myListener);
+
+                expect(baseApi._getListenerCount()).toBe(1);
+                expect(baseApi.removeMsgListener('bar', myListener)).toBe(undefined);
+                expect(baseApi.removeMsgListener('foo', () => {})).toBe(undefined);
+                expect(baseApi._getListenerCount()).toBe(1);
+            });
+
+            it('should not remove a matching listener assigned to a different cased or leading/trailing spaced eventType', () => {
+                let eventType = 'foo';
+                let myListener = () => {};
+                baseApi.addMsgListener(eventType, myListener);
+                expect(baseApi._getListenerCount()).toBe(1);
+
+                // case sensitive
+                baseApi.removeMsgListener(eventType.toUpperCase(), myListener);
+                expect(baseApi._getListenerCount()).toBe(1);
+
+                // leading/trailing space sensitive
+                baseApi.removeMsgListener(` ${eventType}`, myListener);
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener(`${eventType} `, myListener);
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener(` ${eventType} `, myListener);
+                expect(baseApi._getListenerCount()).toBe(1);
+            });
+
+            it('should not remove a matching listener for a different event type', () => {
+                let myListener = () => {};
+                baseApi.addMsgListener('foo', myListener);
+
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener('bar', myListener);
+                expect(baseApi._getListenerCount()).toBe(1);
+            });
+
+            it('should treat empty options as the defaults when checking options for removing a listener', () => {
+                [null, undefined, {},
+                    {once: null}, {once: undefined}, {once: false},
+                    {msgPayloadFilter: null}, {msgPayloadFilter: undefined}
+                ].forEach(defaultOptionEquivalent => {
+                    let myListener = () => {};
+
+                    baseApi.addMsgListener('foo', myListener);
+                    expect(baseApi._getListenerCount()).toBe(1);
+
+                    baseApi.removeMsgListener('foo', myListener, defaultOptionEquivalent);
+                    expect(baseApi._getListenerCount()).toBe(0);
+                });
+            });
+
+            it('should check the options when evaluating a listener for removal', () => {
+                let myListener = () => {};
+
+                // Same eventType and listener; different options from default
+                baseApi.addMsgListener('foo', myListener);
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener('foo', myListener, {once: true});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener('foo', myListener, {msgPayloadFilter: () => {}});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener('foo', myListener, {once: false, msgPayloadFilter: () => {}});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener('foo', myListener, {once: true, msgPayloadFilter: undefined});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener('foo', myListener);
+                expect(baseApi._getListenerCount()).toBe(0);
+
+                // Same eventType and listener; different options from registered
+                let myFilter = () => {};
+                baseApi.addMsgListener('foo', myListener, {once: true, msgPayloadFilter: myFilter});
+                expect(baseApi._getListenerCount()).toBe(1);
+
+                baseApi.removeMsgListener('foo', myListener, {once: true});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener('foo', myListener, {once: true, msgPayloadFilter: null});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener('foo', myListener, {once: true, msgPayloadFilter: undefined});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener('foo', myListener, {once: true, msgPayloadFilter: () => {}});
+                expect(baseApi._getListenerCount()).toBe(1);
+
+                baseApi.removeMsgListener('foo', myListener, {msgPayloadFilter: myFilter});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener('foo', myListener, {once: null, msgPayloadFilter: myFilter});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener('foo', myListener, {once: undefined, msgPayloadFilter: myFilter});
+                expect(baseApi._getListenerCount()).toBe(1);
+                baseApi.removeMsgListener('foo', myListener, {once: false, msgPayloadFilter: myFilter});
+                expect(baseApi._getListenerCount()).toBe(1);
+
+                // Successful removal
+                baseApi.removeMsgListener('foo', myListener, {once: true, msgPayloadFilter: myFilter});
+                expect(baseApi._getListenerCount()).toBe(0);
+            });
+
+            it('should only remove the one listener matching the eventType, listener, and options.  Regardless of number of listeners or the registered order', () => {
+                let myListener = () => {};
+                let myFilter = () => {};
+
+                baseApi.addMsgListener('foo', myListener, {once: true});
+                baseApi.addMsgListener('foo', myListener, {once: true, msgPayloadFilter: myFilter});
+                baseApi.addMsgListener('foo', myListener, {once: true, msgPayloadFilter: () => {}});
+                baseApi.addMsgListener('foo', myListener);
+                baseApi.addMsgListener('foo', myListener, {once: false, msgPayloadFilter: myFilter});
+                baseApi.addMsgListener('foo', myListener, {once: false, msgPayloadFilter: () => {}});
+                expect(baseApi._getListenerCount()).toBe(6);
+
+                baseApi.removeMsgListener('foo', myListener);
+                expect(baseApi._getListenerCount()).toBe(5);
+
+                baseApi.removeMsgListener('foo', myListener, {msgPayloadFilter: myFilter});
+                expect(baseApi._getListenerCount()).toBe(4);
+
+                baseApi.removeMsgListener('foo', myListener, {once: true, msgPayloadFilter: myFilter});
+                expect(baseApi._getListenerCount()).toBe(3);
+
+                baseApi.removeMsgListener('foo', myListener, {once: true});
+                expect(baseApi._getListenerCount()).toBe(2);
+            });
+
+            it('should stop listening for events when the last listener is removed', () => {
+                let mockWindow = {
+                    addEventListener() {},
+                    removeEventListener() {}
+                };
+                baseApi._myWindow = mockWindow;
+
+                spyOn(mockWindow, 'addEventListener');
+                spyOn(mockWindow, 'removeEventListener');
+
+                let listener1 = () => {};
+                let listener2 = () => {};
+
+                // Single event; single listener
+                baseApi.addMsgListener('event1', listener1);
+                expect(mockWindow.addEventListener).toHaveBeenCalledTimes(1);
+                baseApi.removeMsgListener('event1', listener1);
+                expect(mockWindow.removeEventListener).toHaveBeenCalledTimes(1);
+                expect(mockWindow.removeEventListener.calls.mostRecent().args[0]).toBe('message');
+                expect(typeof mockWindow.removeEventListener.calls.mostRecent().args[1]).toBe('function');
+
+                // Single event; multiple listeners
+                mockWindow.addEventListener.calls.reset();
+                mockWindow.removeEventListener.calls.reset();
+
+                baseApi.addMsgListener('event1', listener1);
+                expect(mockWindow.addEventListener).toHaveBeenCalledTimes(1);
+                baseApi.addMsgListener('event1', listener2);
+                expect(mockWindow.addEventListener).toHaveBeenCalledTimes(1);
+                baseApi.removeMsgListener('event1', listener1);
+                expect(mockWindow.removeEventListener).toHaveBeenCalledTimes(0);
+                baseApi.removeMsgListener('event1', listener2);
+                expect(mockWindow.removeEventListener).toHaveBeenCalledTimes(1);
+
+                // multiple events; single listeners
+                mockWindow.addEventListener.calls.reset();
+                mockWindow.removeEventListener.calls.reset();
+
+                baseApi.addMsgListener('event1', listener1);
+                expect(mockWindow.addEventListener).toHaveBeenCalledTimes(1);
+                baseApi.addMsgListener('event2', listener2);
+                expect(mockWindow.addEventListener).toHaveBeenCalledTimes(1);
+                baseApi.removeMsgListener('event1', listener1);
+                expect(mockWindow.removeEventListener).toHaveBeenCalledTimes(0);
+                baseApi.removeMsgListener('event2', listener2);
+                expect(mockWindow.removeEventListener).toHaveBeenCalledTimes(1);
+            });
+        });
     });
 });

--- a/src/modules/lifecycle.js
+++ b/src/modules/lifecycle.js
@@ -8,6 +8,15 @@
 
 import BaseApi from './base';
 
+const LIFECYCLE_HOOK_EVENT_NAME = 'appLifecycleHook';
+const HOOK_NAME_FILTER = function (hookName, msgPayload) {
+    return (typeof msgPayload === 'object' && msgPayload.hook === hookName);
+};
+const BOOTSTRAP_HOOK_FILTER = HOOK_NAME_FILTER.bind(undefined, 'bootstrap');
+const FOCUS_HOOK_FILTER = HOOK_NAME_FILTER.bind(undefined, 'focus');
+const BLUR_HOOK_FILTER = HOOK_NAME_FILTER.bind(undefined, 'blur');
+const STOP_HOOK_FILTER = HOOK_NAME_FILTER.bind(undefined, 'stop');
+
 /**
  * Utilities for monitoring and updating the lifecycle of a PureCloud Client App
  *
@@ -16,6 +25,38 @@ import BaseApi from './base';
  * @since 1.0.0
  */
 class LifecycleApi extends BaseApi {
+    /**
+     * Attach a listener function to be called when PureCloud has loaded the app.
+     *
+     * This provides a hook for implementers to do any post-load initialization
+     * work with PureCloud.  Implementers should call bootstrapped() after initialization work is
+     * complete.  PureCloud will eventually timeout and show the app anyway if the bootstrapped()
+     * function is not called in a timely manor.
+     *
+     * @param {function} listener - The function to call when PureCloud is ready for the app to
+     * perform post-load initialization work.  This function will be passed the lifecycle event and
+     * does not augment the this context.
+     * @param {boolean} once - If the listener should only be invoked once or repeatedly; true by default.
+     *
+     * @example
+     * myClientApp.lifecycle.addBootstrapListener(() => {
+     *   // Perform bootstrap (post-load init) work
+     *
+     *   // Simulate 500ms delay
+     *   window.setTimeout(() => {
+     *     myClientApp.lifecycle.bootstrapped();
+     *   }, 500);
+     * });
+     *
+     * @since 1.0.0
+     */
+    addBootstrapListener(listener, once = true) {
+        this.addMsgListener(LIFECYCLE_HOOK_EVENT_NAME, listener, {
+            once,
+            msgPayloadFilter: BOOTSTRAP_HOOK_FILTER
+        });
+    }
+
     /**
      * Signals PureCloud that this app has finished its initialization work and
      * can be shown to the user.
@@ -30,6 +71,173 @@ class LifecycleApi extends BaseApi {
     }
 
     /**
+     * Remove a previously registered bootstrap lifecycle event listener.
+     *
+     * @param {function} listener - The previously registered bootstrap event listener.
+     * @param {boolean} once - false if once was explicitly set as false when adding the listener;
+     *  otherwise, you can explicitly provide true or rely on the default.
+     *
+     * @example
+     * let onBootstrap = evt => {
+     *   // Perform bootstrap (post-load init) work
+     *
+     *   // Remove the listener. [Note:] once must be provided to match
+     *   myClientApp.lifecycle.removeBootstrapListener(onBootstrap, false);
+     * };
+     * // Note once must be set to false or the listener will be auto-removed by default
+     * myClientApp.lifecycle.addBootstrapListener(onBootstrap, false);
+     *
+     * @since 1.0.0
+     */
+    removeBootstrapListener(listener, once = true) {
+        this.removeMsgListener(LIFECYCLE_HOOK_EVENT_NAME, listener, {
+            once,
+            msgPayloadFilter: BOOTSTRAP_HOOK_FILTER
+        });
+    }
+
+    /**
+     * Attach a listener function to be called when the user has re-focused your app.
+     * [Note:] Focus is not called on initial show.  Use the bootstrap listener for that work.
+     *
+     * @param {function} listener - The function to call when the user has re-focused your
+     * app in the UI.
+     * @param {boolean} once - If the listener should only be invoked once or repeatedly; false by default.
+     *
+     * @example
+     * let onFocus = evt => {
+     *   // Perform focus work
+     * };
+     * myClientApp.lifecycle.addFocusListener(onFocus);
+     *
+     * // Don't forget to remove this listener inside the stop event listener
+     * myClientApp.lifecycle.addStopListener(() => {
+     *   myClientApp.lifecycle.removeFocusListener(onFocus);
+     * });
+     *
+     * @since 1.0.0
+     */
+    addFocusListener(listener, once = false) {
+        this.addMsgListener(LIFECYCLE_HOOK_EVENT_NAME, listener, {
+            once,
+            msgPayloadFilter: FOCUS_HOOK_FILTER
+        });
+    }
+
+    /**
+     * Remove a previously registered focus lifecycle event listener
+     *
+     * @param {function} listener - The previously registered focus event listener.
+     * @param {boolean} once - true if once was explicitly set as true when adding the listener;
+     *  otherwise, you can explicitly provide false or rely on the default.
+     *
+     * @example
+     * let onFocus = evt => {
+     *   // Perform focus work
+     * };
+     * myClientApp.lifecycle.addFocusListener(onFocus);
+     *
+     * // Don't forget to remove this listener inside the stop event listener
+     * myClientApp.lifecycle.addStopListener(() => {
+     *   myClientApp.lifecycle.removeFocusListener(onFocus);
+     * });
+     *
+     * @since 1.0.0
+     */
+    removeFocusListener(listener, once = false) {
+        this.removeMsgListener(LIFECYCLE_HOOK_EVENT_NAME, listener, {
+            once,
+            msgPayloadFilter: FOCUS_HOOK_FILTER
+        });
+    }
+
+    /**
+     * Attach a listener function to be called when the user has left/blurred your app.
+     *
+     * @param {function} listener - The function to call when the user has left your
+     * app in the UI.
+     * @param {boolean} once - If the listener should only be invoked once or repeatedly; false by default.
+     *
+     * @example
+     * let onBlur = evt => {
+     *   // Perform blur work
+     * };
+     * myClientApp.lifecycle.addBlurListener(onBlur);
+     *
+     * // Don't forget to remove this listener inside the stop event listener
+     * myClientApp.lifecycle.addStopListener(() => {
+     *   myClientApp.lifecycle.removeBlurListener(onBlur);
+     * });
+     *
+     * @since 1.0.0
+     */
+    addBlurListener(listener, once = false) {
+        this.addMsgListener(LIFECYCLE_HOOK_EVENT_NAME, listener, {
+            once,
+            msgPayloadFilter: BLUR_HOOK_FILTER
+        });
+    }
+
+    /**
+     * Remove a previously registered blur lifecycle event listener
+     *
+     * @param {function} listener - The previously registered blur event listener.
+     * @param {boolean} once - true if once was explicitly set as true when adding the listener;
+     *  otherwise, you can explicitly provide false or rely on the default.
+     *
+     * @example
+     * let onBlur = evt => {
+     *   // Perform blur work
+     * };
+     * myClientApp.lifecycle.addBlurListener(onBlur);
+     *
+     * // Don't forget to remove this listener inside the stop event listener
+     * myClientApp.lifecycle.addStopListener(() => {
+     *   myClientApp.lifecycle.removeBlurListener(onBlur);
+     * });
+     *
+     * @since 1.0.0
+     */
+    removeBlurListener(listener, once = false) {
+        this.removeMsgListener(LIFECYCLE_HOOK_EVENT_NAME, listener, {
+            once,
+            msgPayloadFilter: BLUR_HOOK_FILTER
+        });
+    }
+
+    /**
+     * Attach a listener function to be called when PureCloud is about to shut down your app.
+     * For instance, this can happen if the user has loaded too many apps and your app needs to be
+     * stopped to conserve resources.
+     *
+     * This provides a hook for you to do any app cleanup work.  Implementers should call
+     * stopped() after shutdown work is complete.  PureCloud will eventually timeout and permanenty
+     * remove the app anyway if stopped() is not called in a timely manor.
+     *
+     * @param {function} listener - The function to call when PureCloud is about to stop this app.
+     * This function will be passed the lifecycle event and does not augment the this context.
+     * @param {boolean} once - If the listener should only be invoked once or repeatedly; true by default.
+     *
+     * @example
+     * myClientApp.lifecycle.addStopListener(() => {
+     *   // Perform shutdown work
+     *
+     *   // Simulate 500ms delay
+     *   window.setTimeout(() => {
+     *     myClientApp.lifecycle.stopped();
+     *   }, 500);
+     * });
+     *
+     * @since 1.0.0
+     */
+    addStopListener(listener, once = true) {
+        this.addMsgListener(LIFECYCLE_HOOK_EVENT_NAME, listener, {
+            once,
+            msgPayloadFilter: STOP_HOOK_FILTER
+        });
+    }
+
+    /**
      * Signals PureCloud that this app has finished its tear down work and the iframe
      * can be removed from purecloud permanently.
      *
@@ -40,6 +248,36 @@ class LifecycleApi extends BaseApi {
      */
     stopped() {
         super.sendMsgToPc('stopped');
+    }
+
+    /**
+     * Remove a previously registered stop lifecycle event listener.
+     *
+     * @param {function} listener - The previously registered stop event listener.
+     * @param {boolean} once - false if once was explicitly set as false when adding the listener;
+     *  otherwise, you can explicitly provide true or rely on the default.
+     *
+     * @example
+     * let onStop = evt => {
+     *   // Perform cleanup work
+     *
+     *   // Don't forget to notify PureCloud on complete
+     *   myClientApp.lifecycle.stopped();
+     *
+     *   // Remove the stop listener (since you passed false for the once option)
+     *   // Note: You must also pass false for once to match the listener
+     *   myClientApp.lifecycle.removeStopListener(onStop, false);
+     * };
+     * // Note: once must be set to false or the listener will be auto-removed by default
+     * myClientApp.lifecycle.addStopListener(onStop, false);
+     *
+     * @since 1.0.0
+     */
+    removeStopListener(listener, once = true) {
+        this.removeMsgListener(LIFECYCLE_HOOK_EVENT_NAME, listener, {
+            once,
+            msgPayloadFilter: STOP_HOOK_FILTER
+        });
     }
 }
 

--- a/src/modules/lifecycleSpec.js
+++ b/src/modules/lifecycleSpec.js
@@ -1,0 +1,326 @@
+/* eslint-env jasmine */
+import LifecycleApi from './lifecycle';
+
+const APPS_API_PROTOCOL = 'purecloud-client-apps';
+
+export default describe('LifecycleApi', () => {
+    const targetPcOrigin = 'https://subdomain.envdomain.com';
+    const baseProtoDetails = {
+        protocol: APPS_API_PROTOCOL,
+        protocolAgentName: 'bar',
+        protocolAgentVersion: 'baz'
+    };
+    let lifecycleApi = null;
+
+    beforeEach(() => {
+        lifecycleApi = new LifecycleApi(Object.assign({}, {targetPcOrigin}, baseProtoDetails));
+    });
+
+    describe('lifecycleEvents', () => {
+        let mockParent = null;
+        let mockWindow = null;
+        let fireEvent = null;
+        const basePayloadData = {
+            protocol: APPS_API_PROTOCOL
+        };
+
+        const hookCases = [{
+            hook: 'bootstrap',
+            onceDefault: true
+        }, {
+            hook: 'focus',
+            onceDefault: false
+        }, {
+            hook: 'blur',
+            onceDefault: false
+        }, {
+            hook: 'stop',
+            onceDefault: true
+        }];
+
+        beforeEach(() => {
+            mockParent = {};
+            mockWindow = {
+                addEventListener() {},
+                removeEventListener() {}
+            };
+            lifecycleApi._myWindow = mockWindow;
+            lifecycleApi._myParent = mockParent;
+
+            fireEvent = function () {
+                lifecycleApi._onMsg(...arguments);
+            };
+        });
+
+        it('should allow lifecycle listeners to be attached', () => {
+            hookCases.forEach(currHookCase => {
+                testLifecycleHookListener(currHookCase.hook);
+            });
+        });
+
+        it('should include the once flag in the listener equality check', () => {
+            hookCases.forEach(currHookCase => {
+                testLifecycleHookListenerOnceEquality(currHookCase.hook);
+            });
+        });
+
+        it('should register hook listeners uniquely, so that the caller can use the same function if desired', () => {
+            hookCases.forEach(currHookCase => {
+                testLifecycleHookListenerIsolation(currHookCase.hook);
+            });
+        });
+
+        it('should allow lifecycle listeners to be removed', () => {
+            hookCases.forEach(currHookCase => {
+                testLifecycleHookListenerRemoval(currHookCase.hook);
+            });
+        });
+
+        it('should allow lifecycle listeners to be attached in once mode', () => {
+            hookCases.forEach(currHookCase => {
+                testLifecycleHookListenerOnce(currHookCase.hook);
+            });
+        });
+
+        it('should provide provide once defaults for each listener type', () => {
+            hookCases.forEach(currHookCase => {
+                testLifecycleHookListenerOnceDefault(currHookCase.hook, currHookCase.onceDefault);
+            });
+        });
+
+        it('should have consistent once default param values for each listener add/remove pair', () => {
+            hookCases.forEach(currHookCase => {
+                testAddRemoveOnceDefaultConsistency(currHookCase.hook);
+            });
+        });
+
+        function testLifecycleHookListener(hook) {
+            let myObj = {
+                myListener() {}
+            };
+            spyOn(myObj, 'myListener');
+
+            let validEvent = {
+                source: mockParent,
+                origin: targetPcOrigin,
+                data: Object.assign({}, basePayloadData, {
+                    purecloudEventType: 'appLifecycleHook',
+                    hook
+                })
+            };
+
+            // Always pass false to test multiple calls
+            let hookFnName = hook.charAt(0).toUpperCase() + hook.substring(1);
+            lifecycleApi[`add${hookFnName}Listener`](myObj.myListener, false);
+
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(1);
+
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(2);
+
+            // This event should not trigger the listener
+            fireEvent({
+                source: mockParent,
+                origin: targetPcOrigin,
+                data: Object.assign({}, basePayloadData, {
+                    purecloudEventType: 'appLifecycleHook',
+                    hook: `someOther-${hook}`
+                })
+            });
+            expect(myObj.myListener).toHaveBeenCalledTimes(2);
+        }
+
+        function testLifecycleHookListenerOnceEquality(hook) {
+            let myObj = {
+                myListener() {}
+            };
+            spyOn(myObj, 'myListener');
+
+            let validEvent = {
+                source: mockParent,
+                origin: targetPcOrigin,
+                data: Object.assign({}, basePayloadData, {
+                    purecloudEventType: 'appLifecycleHook',
+                    hook
+                })
+            };
+
+            let hookFnName = hook.charAt(0).toUpperCase() + hook.substring(1);
+
+            lifecycleApi[`add${hookFnName}Listener`](myObj.myListener, true);
+            lifecycleApi[`add${hookFnName}Listener`](myObj.myListener, false);
+
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(2);
+
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(3);
+        }
+
+        // Tests that each lifecycle hook can be add/removed in isolation of the others
+        function testLifecycleHookListenerIsolation(hook) {
+            let myObj = {
+                myListener() {}
+            };
+            spyOn(myObj, 'myListener');
+
+            let hookEvents = [];
+
+            // Attach the same listener to every hook
+            hookCases.forEach(currCase => {
+                let currHook = currCase.hook;
+                let hookFnName = currHook.charAt(0).toUpperCase() + currHook.substring(1);
+
+                // Always pass false to ensure consistent tests
+                lifecycleApi[`add${hookFnName}Listener`](myObj.myListener, false);
+
+                hookEvents.push({
+                    source: mockParent,
+                    origin: targetPcOrigin,
+                    data: Object.assign({}, basePayloadData, {
+                        purecloudEventType: 'appLifecycleHook',
+                        hook: currHook
+                    })
+                });
+            });
+
+            // Fire an event for each hook
+            hookEvents.forEach(currEvent => {
+                fireEvent(currEvent);
+            });
+
+            // Each listener should be called
+            expect(myObj.myListener).toHaveBeenCalledTimes(hookCases.length);
+
+            // Remove the listener for the hook under test
+            let hookFnName = hook.charAt(0).toUpperCase() + hook.substring(1);
+            lifecycleApi[`remove${hookFnName}Listener`](myObj.myListener, false);
+
+            // Fire an event for each hook
+            hookEvents.forEach(currEvent => {
+                fireEvent(currEvent);
+            });
+
+            // All but the removed hook should be called
+            expect(myObj.myListener).toHaveBeenCalledTimes((hookCases.length * 2) - 1);
+        }
+
+        function testLifecycleHookListenerRemoval(hook) {
+            let myObj = {
+                myListener() {}
+            };
+            spyOn(myObj, 'myListener');
+
+            let validEvent = {
+                source: mockParent,
+                origin: targetPcOrigin,
+                data: Object.assign({}, basePayloadData, {
+                    purecloudEventType: 'appLifecycleHook',
+                    hook
+                })
+            };
+
+            // Always pass false to test removal
+            let hookFnName = hook.charAt(0).toUpperCase() + hook.substring(1);
+            lifecycleApi[`add${hookFnName}Listener`](myObj.myListener, false);
+
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(1);
+
+            // Ensure it's not a once listener
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(2);
+
+            // Ensure the listener is used in the equality check for removal
+            lifecycleApi[`remove${hookFnName}Listener`](() => {}, false);
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(3);
+
+            // Ensure once is used in the equality check for removal
+            lifecycleApi[`remove${hookFnName}Listener`](myObj.myListener, true);
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(4);
+
+            // Finally, pass the right listener and once to actually remove it
+            lifecycleApi[`remove${hookFnName}Listener`](myObj.myListener, false);
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(4);
+        }
+
+        function testLifecycleHookListenerOnce(hook) {
+            let myObj = {
+                myListener() {}
+            };
+            spyOn(myObj, 'myListener');
+
+            let validEvent = {
+                source: mockParent,
+                origin: targetPcOrigin,
+                data: Object.assign({}, basePayloadData, {
+                    purecloudEventType: 'appLifecycleHook',
+                    hook
+                })
+            };
+
+            let hookFnName = hook.charAt(0).toUpperCase() + hook.substring(1);
+            // Always pass true to test once
+            lifecycleApi[`add${hookFnName}Listener`](myObj.myListener, true);
+
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(1);
+
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(1);
+        }
+
+        function testLifecycleHookListenerOnceDefault(hook, onceDefault) {
+            let myObj = {
+                myListener() {}
+            };
+            spyOn(myObj, 'myListener');
+
+            let validEvent = {
+                source: mockParent,
+                origin: targetPcOrigin,
+                data: Object.assign({}, basePayloadData, {
+                    purecloudEventType: 'appLifecycleHook',
+                    hook
+                })
+            };
+
+            let hookFnName = hook.charAt(0).toUpperCase() + hook.substring(1);
+            lifecycleApi[`add${hookFnName}Listener`](myObj.myListener);
+
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(1);
+
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(onceDefault ? 1 : 2);
+        }
+
+        function testAddRemoveOnceDefaultConsistency(hook) {
+            let myObj = {
+                myListener() {}
+            };
+            spyOn(myObj, 'myListener');
+
+            let validEvent = {
+                source: mockParent,
+                origin: targetPcOrigin,
+                data: Object.assign({}, basePayloadData, {
+                    purecloudEventType: 'appLifecycleHook',
+                    hook
+                })
+            };
+
+            let hookFnName = hook.charAt(0).toUpperCase() + hook.substring(1);
+            lifecycleApi[`add${hookFnName}Listener`](myObj.myListener);
+            // Immediately call remove to test the default once param is the same for remove as add
+            lifecycleApi[`remove${hookFnName}Listener`](myObj.myListener);
+
+            fireEvent(validEvent);
+            expect(myObj.myListener).toHaveBeenCalledTimes(0);
+        }
+    });
+});


### PR DESCRIPTION
* Add base utility to generically subscribe to messages from PC from any module
    * Supports add, remove, once, and listener provided filter methods
    * These utilities are inteded to be used by modules to provide user-space apis
* Add specific subscribe methods in lifecycle module for all lifecycle events
* Add full documentation for user-facing and internal methods
* Add unit tests for base lister functionality
    * (add, remove, triggering, filtering, once)
* Add unit tests for lifecycle event listeners
    * (add, remove, triggering, once, once defaults)