### PR TITLE
Remove the bin directory to fix npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   ],
   "directories": {
     "lib": "src",
-    "bin": "scripts",
     "examples": "examples"
   },
   "scripts": {


### PR DESCRIPTION
Current scripts are for dev purposes and are not included in the
deployed pkg.  NPM installs were failing when trying to prepare the
non-existant scripts for inclusion on the path.