### PR TITLE
Fix disabled refresh button after fetch failure

### DIFF
--- a/examples/interactionsDemo.html
+++ b/examples/interactionsDemo.html
@@ -272,6 +272,7 @@
 
                                 if (conversations.length === 0) {
                                     setErrorState('No conversations were found for you in the past 30 days');
+                                    reloadButtonEl.disabled = false;
                                     return;
                                 }
 
@@ -292,9 +293,9 @@
                                 setHidden(conversationsTable, false);
                                 reloadButtonEl.disabled = false;
                             }).catch(function (reason) {
-                                reloadButtonEl.disabled = false;
                                 setHidden(reloadingEl, true);
                                 setErrorState('Failed to fetch your conversations');
+                                reloadButtonEl.disabled = false;
                             });
                         }
 


### PR DESCRIPTION
Moving the button enabling to the end of the method broke this fast-fail
case