### PR TITLE
Add usw2 support to SDK

### DIFF
--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -4,7 +4,8 @@ const PC_ENV_TLDS = [
     'mypurecloud.com.au',
     'mypurecloud.ie',
     'mypurecloud.jp',
-    'mypurecloud.de'
+    'mypurecloud.de',
+    'usw2.pure.cloud'
 ];
 
 let DEFAULT_PC_ENV = null;

--- a/src/utils/envSpec.js
+++ b/src/utils/envSpec.js
@@ -7,7 +7,8 @@ export default describe('env utils', () => {
         'mypurecloud.com.au',
         'mypurecloud.ie',
         'mypurecloud.jp',
-        'mypurecloud.de'
+        'mypurecloud.de',
+        'usw2.pure.cloud'
     ];
 
     it('should provide the default environment', () => {
@@ -62,7 +63,8 @@ export default describe('env utils', () => {
             `https://apps.${seedTld}`, // FQDN
             `. ${seedTld} /`, // Inner whitespace
             'mypurecloud.io', // Valid TLD, but invalid PC Env TLD
-            'mypurecloud.com.evil.com' // Evil subdomains
+            'mypurecloud.com.evil.com', // Evil subdomains
+            'usw3.pure.cloud' // Valid PC Env TLD, but invalid subdomain
         ];
 
         variations.forEach(currTld => {


### PR DESCRIPTION
Adds usw2 to the supported environments in the SDK.  I'll update the examples after this is deployed.