### PR TITLE
ATEAM-281: Preserve pcEnvironment query param after oauth flow

### DIFF
--- a/dev.rollup.config.js
+++ b/dev.rollup.config.js
@@ -24,7 +24,7 @@ try {
 const transformExampleSdkUrl = (buffer) => {
     return buffer.replace(
         /(\s*<script.*src=")([^"]+client-app-sdk[^"]+)(".*<\/script>\s*)/i,
-        '$1' + (BROWSER_FILENAME || '$2') + '$3\n'
+        '$1' + (`/${BROWSER_FILENAME}` || '$2') + '$3\n'
     );
 };
 

--- a/examples/agentInteractionsDemo/app.js
+++ b/examples/agentInteractionsDemo/app.js
@@ -158,19 +158,6 @@ new Vue({
             return;
         }
 
-        /*
-            * Note: To use this app in your own org, you will need to create your own OAuth2 Client(s)
-            * in your PureCloud org.  After creating the Implicit grant client, map the client id(s) to
-            * the specified region key(s) in the object below, deploy the page, and configure an app to point to that URL.
-            */
-        let pcOAuthClientIds = {'mypurecloud.com': 'implicit-oauth-client-id-here'};
-
-        let clientId = pcOAuthClientIds[pcEnvironment];
-        if (!clientId) {
-            this.errorMessage = pcEnvironment + ': Unknown/Unsupported PureCloud Environment';
-            return;
-        }
-
         let client = platformClient.ApiClient.instance;
         client.setEnvironment(pcEnvironment);
         client.setPersistSettings(true);
@@ -198,17 +185,9 @@ new Vue({
         let authenticated = false;
         let agentUserId = "";
 
-        let redirectUrl = window.location.origin;
-        if (!redirectUrl) {
-            redirectUrl = window.location.protocol + '//' + window.location.host;
-        }
-        redirectUrl += window.location.pathname;
-
         // Authentication and main flow
-        client.loginImplicitGrant(clientId, redirectUrl, { state: ("pcEnvironment=" + pcEnvironment) })
-            .then((data) => {
-                window.history.replaceState(null, null, window.location.pathname + "?" + data.state);
-                // Get userme info
+        authenticate(client, pcEnvironment)
+            .then(() => {
                 authenticated = true;
                 return usersApi.getUsersMe({ "expand": ["presence"] });
             })
@@ -268,8 +247,10 @@ new Vue({
             })
             .catch((err) => {
                 console.log(err);
-                this.errorMessage = !authenticated ? "Failed to Authenticate with PureCloud" :
-                                    "Failed to fetch/display profile";
+                this.errorMessage =
+                    !authenticated
+                        ? "Failed to Authenticate with PureCloud - " + err.message
+                        : "Failed to fetch/display profile";
             });
     },
 });

--- a/examples/agentInteractionsDemo/app.js
+++ b/examples/agentInteractionsDemo/app.js
@@ -206,7 +206,8 @@ new Vue({
 
         // Authentication and main flow
         client.loginImplicitGrant(clientId, redirectUrl, { state: ("pcEnvironment=" + pcEnvironment) })
-            .then(() => {
+            .then((data) => {
+                window.history.replaceState(null, null, window.location.pathname + "?" + data.state);
                 // Get userme info
                 authenticated = true;
                 return usersApi.getUsersMe({ "expand": ["presence"] });

--- a/examples/agentInteractionsDemo/index.html
+++ b/examples/agentInteractionsDemo/index.html
@@ -17,6 +17,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/vue"></script>
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
+    <script src="../utils/oauth.js"></script>
     <script src="util.js"></script>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
         integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">

--- a/examples/externalContactsDemo/index.html
+++ b/examples/externalContactsDemo/index.html
@@ -25,6 +25,7 @@
 
     <script src="https://sdk-cdn.mypurecloud.com/javascript/72.0.0/purecloud-platform-client-v2.min.js"></script>
     <script src="https://sdk-cdn.mypurecloud.com/client-apps/1.4.0/purecloud-client-app-sdk-49c1570bfd8967d8861435e0e7178035.min.js"></script>
+    <script src="../utils/oauth.js"></script>
     <script src="script.js"></script>
 </head>
 

--- a/examples/externalContactsDemo/script.js
+++ b/examples/externalContactsDemo/script.js
@@ -15,21 +15,6 @@ document.addEventListener('DOMContentLoaded', function () {
         );
         return;
     }
-    updateProgressBar(40);
-
-    /*
-    * Note: To use this app in your own org, you will need to create your own OAuth2 Client(s)
-    * in your PureCloud org.  After creating the Implicit grant client, map the client id(s) to
-    * the specified region key(s) in the object below, deploy the page, and configure an app to point to that URL.
-    */
-    let pcOAuthClientIds = { 'mypurecloud.com': 'implicit-oauth-client-id-here' };
-    let clientId = pcOAuthClientIds[pcEnvironment];
-    if (!clientId) {
-        setErrorState(
-            pcEnvironment + ': Unknown/Unsupported PureCloud Environment'
-        );
-        return;
-    }
     updateProgressBar(60);
 
     let client = platformClient.ApiClient.instance;
@@ -71,29 +56,19 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         });
 
-    let redirectUrl = window.location.origin;
-    if (!redirectUrl) {
-        redirectUrl = window.location.protocol + '//' + window.location.host;
-    }
-    redirectUrl += window.location.pathname;
-
     // Authenticate with PureCloud
     let authenticated = false;
     let userDataAcquired = false;
 
-    client
-        .loginImplicitGrant(clientId, redirectUrl, {
-            state: 'pcEnvironment=' + pcEnvironment
-        })
-        .then(function (data) {
-            window.history.replaceState(null, null, window.location.pathname + "?" + data.state);
+    authenticate(client, pcEnvironment)
+        .then(() => {
             updateProgressBar(100);
             authenticated = true;
             return new platformClient.UsersApi().getUsersMe({
                 expand: ['authorization']
             });
         })
-        .then(function (profileData) {
+        .then(profileData => {
             userDataAcquired = true;
             // Check if the current user will be able to view external contacts
             let permissions = profileData.authorization.permissions;
@@ -138,9 +113,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 setErrorState('You do not have the proper permissions to view external contacts.');
             }
         })
-        .catch(function () {
+        .catch(err => {
             if (!authenticated) {
-                setErrorState('Failed to Authenticate with PureCloud');
+                setErrorState('Failed to Authenticate with PureCloud - ' + err.message);
             } else if (!userDataAcquired) {
                 setErrorState('Failed to locate user in PureCloud');
             }

--- a/examples/externalContactsDemo/script.js
+++ b/examples/externalContactsDemo/script.js
@@ -85,7 +85,8 @@ document.addEventListener('DOMContentLoaded', function () {
         .loginImplicitGrant(clientId, redirectUrl, {
             state: 'pcEnvironment=' + pcEnvironment
         })
-        .then(function () {
+        .then(function (data) {
+            window.history.replaceState(null, null, window.location.pathname + "?" + data.state);
             updateProgressBar(100);
             authenticated = true;
             return new platformClient.UsersApi().getUsersMe({

--- a/examples/interactionsDemo.html
+++ b/examples/interactionsDemo.html
@@ -21,6 +21,8 @@
 
         <script src="https://sdk-cdn.mypurecloud.com/javascript/72.0.0/purecloud-platform-client-v2.min.js"></script>
         <script src="https://sdk-cdn.mypurecloud.com/client-apps/1.4.0/purecloud-client-app-sdk-49c1570bfd8967d8861435e0e7178035.min.js"></script>
+        <script src="utils/oauth.js"></script>
+
         <style>
             body {
                 margin-left: 20px;
@@ -161,18 +163,6 @@
                     return;
                 }
 
-                /*
-                * Note: To use this app in your own org, you will need to create your own OAuth2 Client(s)
-                * in your PureCloud org.  After creating the Implicit grant client, map the client id(s) to
-                * the specified region key(s) in the object below, deploy the page, and configure an app to point to that URL.
-                */
-                let pcOAuthClientIds = { 'mypurecloud.com': 'implicit-oauth-client-id-here' };
-                let clientId = pcOAuthClientIds[pcEnvironment];
-                if (!clientId) {
-                    setErrorState(pcEnvironment + ': Unknown/Unsupported PureCloud Environment');
-                    return;
-                }
-
                 let client = platformClient.ApiClient.instance;
                 client.setEnvironment(pcEnvironment);
 
@@ -192,18 +182,12 @@
                  *  This UI is used for testing purposes to manually navigate to a conversation by ID.
                  *  It purposefully ignores the fact that a user may not be authorized to view interactions.
                  */
-                 document.querySelector('.manual-example button').addEventListener('click', function() {
+                document.querySelector('.manual-example button').addEventListener('click', function() {
                     let conversationId = document.querySelector('#conversation-id').value.trim();
                     if (conversationId) {
                         clientApp.conversations.showInteractionDetails(conversationId);
                     }
                 });
-
-                let redirectUrl = window.location.origin;
-                if (!redirectUrl) {
-                    redirectUrl = window.location.protocol + '//' + window.location.host;
-                }
-                redirectUrl += window.location.pathname;
 
                 // Authenticate with PureCloud
                 let authenticatingEl = document.querySelector('.authenticating');
@@ -214,13 +198,12 @@
                 let canViewInteraction = false;
                 let canViewWrapUpCodes = false;
 
-                client.loginImplicitGrant(clientId, redirectUrl, { state: ('pcEnvironment=' + pcEnvironment) })
-                    .then(function (data) {
-                        window.history.replaceState(null, null, window.location.pathname + "?" + data.state);
+                authenticate(client, pcEnvironment)
+                    .then(() => {
                         authenticated = true;
-                        return new platformClient.UsersApi().getUsersMe({ 'expand': ['authorization'] });
+                        return new platformClient.UsersApi().getUsersMe({ 'expand': ['authorization'] })
                     })
-                    .then(function (profileData) {
+                    .then(profileData => {
                         userDataAcquired = true;
 
                         // Check if the current user will be able to view interaction details
@@ -312,7 +295,7 @@
                         setHidden(authenticatingEl, true);
 
                         if (!authenticated) {
-                            setErrorState('Failed to Authenticate with PureCloud');
+                            setErrorState('Failed to Authenticate with PureCloud - ' + err.message);
                         } else if (!userDataAcquired) {
                             setErrorState('Failed to locate user in PureCloud');
                         }

--- a/examples/interactionsDemo.html
+++ b/examples/interactionsDemo.html
@@ -215,7 +215,8 @@
                 let canViewWrapUpCodes = false;
 
                 client.loginImplicitGrant(clientId, redirectUrl, { state: ('pcEnvironment=' + pcEnvironment) })
-                    .then(function () {
+                    .then(function (data) {
+                        window.history.replaceState(null, null, window.location.pathname + "?" + data.state);
                         authenticated = true;
                         return new platformClient.UsersApi().getUsersMe({ 'expand': ['authorization'] });
                     })

--- a/examples/profile.html
+++ b/examples/profile.html
@@ -139,7 +139,8 @@
           let authenticatingEl = document.querySelector('.authenticating');
           setHidden(authenticatingEl, false);
           client.loginImplicitGrant(clientId, redirectUrl, {state: ('pcEnvironment=' + pcEnvironment)})
-            .then(function() {
+            .then(function(data) {
+                window.history.replaceState(null, null, window.location.pathname + "?" + data.state);
                 authenticated = true;
 
                 return new platformClient.UsersApi().getUsersMe();

--- a/examples/profile.html
+++ b/examples/profile.html
@@ -15,6 +15,7 @@
 
         <script src="https://sdk-cdn.mypurecloud.com/javascript/72.0.0/purecloud-platform-client-v2.min.js"></script>
         <script src="https://sdk-cdn.mypurecloud.com/client-apps/1.4.0/purecloud-client-app-sdk-49c1570bfd8967d8861435e0e7178035.min.js"></script>
+        <script src="utils/oauth.js"></script>
 
         <style>
             body {
@@ -89,75 +90,56 @@
         </section>
 
         <script>document.addEventListener('DOMContentLoaded', function () {
-          /*
-           * The Client Apps SDK can interpolate the current PC Environment into your app's URL
-           * EX: https://mypurecloud.github.io/client-app-sdk/profile.html?pcEnvironment={{pcEnvironment}}
-           *
-           * Reading the PC Environment from the query string or state param returned from OAuth2 response
-           */
-          let pcEnvironment = getEmbeddingPCEnv();
-          if (!pcEnvironment) {
-              setErrorState('Cannot identify App Embeddding context.  Did you forget to add pcEnvironment={{pcEnvironment}} to your app\'s query string?');
-              return;
-          }
+            /*
+            * The Client Apps SDK can interpolate the current PC Environment into your app's URL
+            * EX: https://mypurecloud.github.io/client-app-sdk/profile.html?pcEnvironment={{pcEnvironment}}
+            *
+            * Reading the PC Environment from the query string or state param returned from OAuth2 response
+            */
+            let pcEnvironment = getEmbeddingPCEnv();
+            if (!pcEnvironment) {
+                setErrorState('Cannot identify App Embeddding context.  Did you forget to add pcEnvironment={{pcEnvironment}} to your app\'s query string?');
+                return;
+            }
 
-          /*
-           * Note: To use this app in your own org, you will need to create your own OAuth2 Client(s)
-           * in your PureCloud org.  After creating the Implicit grant client, map the client id(s) to
-           * the specified region key(s) in the object below, deploy the page, and configure an app to point to that URL.
-           */
-          let pcOAuthClientIds = {'mypurecloud.com': 'implicit-oauth-client-id-here'};
+            let platformClient = window.require('platformClient');
+            let client = platformClient.ApiClient.instance;
+            client.setEnvironment(pcEnvironment);
 
-          let clientId = pcOAuthClientIds[pcEnvironment];
-          if (!clientId) {
-              setErrorState(pcEnvironment + ': Unknown/Unsupported PureCloud Environment');
-              return;
-          }
+            let clientApp = null;
+            try {
+                clientApp = new window.purecloud.apps.ClientApp({
+                    pcEnvironment: pcEnvironment
+                });
+            } catch (e) {
+                setErrorState(pcEnvironment + ': Unknown/Unsupported PureCloud Embed Context');
+                return;
+            }
 
-          let platformClient = window.require('platformClient');
-          let client = platformClient.ApiClient.instance;
-          client.setEnvironment(pcEnvironment);
+            // Authenticate with PureCloud
+            let authenticated = false;
+            let authenticatingEl = document.querySelector('.authenticating');
+            setHidden(authenticatingEl, false);
+            authenticate(client, pcEnvironment)
+                .then(() => {
+                    authenticated = true;
+                    return new platformClient.UsersApi().getUsersMe();
+                })
+                .then(profileData => {
+                    setHidden(authenticatingEl, true);
 
-          let clientApp = null;
-          try {
-            clientApp = new window.purecloud.apps.ClientApp({
-                pcEnvironment: pcEnvironment
-            });
-          } catch (e) {
-              setErrorState(pcEnvironment + ': Unknown/Unsupported PureCloud Embed Context');
-              return;
-          }
-
-          let redirectUrl = window.location.origin;
-          if (!redirectUrl) {
-              redirectUrl = window.location.protocol + '//' + window.location.host;
-          }
-          redirectUrl += window.location.pathname;
-
-          // Authenticate with PureCloud
-          let authenticated = false;
-          let authenticatingEl = document.querySelector('.authenticating');
-          setHidden(authenticatingEl, false);
-          client.loginImplicitGrant(clientId, redirectUrl, {state: ('pcEnvironment=' + pcEnvironment)})
-            .then(function(data) {
-                window.history.replaceState(null, null, window.location.pathname + "?" + data.state);
-                authenticated = true;
-
-                return new platformClient.UsersApi().getUsersMe();
-            })
-            .then(function(profileData) {
-                setHidden(authenticatingEl, true);
-
-                let profileEl = document.querySelector('.user-profile');
-                renderUserProfile(profileEl, profileData);
-                setHidden(profileEl, false);
-            })
-            .catch(function(err) {
-                setHidden(authenticatingEl, true);
-
-                setErrorState(!authenticated ? 'Failed to Authenticate with PureCloud' :
-                    'Failed to fetch/display your profile');
-            });
+                    let profileEl = document.querySelector('.user-profile');
+                    renderUserProfile(profileEl, profileData);
+                    setHidden(profileEl, false);
+                })
+                .catch(err => {
+                    setHidden(authenticatingEl, true);
+                    setErrorState(
+                        !authenticated
+                            ? 'Failed to Authenticate with PureCloud - ' + err.message
+                            : 'Failed to fetch/display your profile'
+                    );
+                });
 
             // ----- Helper Functions
 

--- a/examples/utils/oauth.js
+++ b/examples/utils/oauth.js
@@ -1,0 +1,21 @@
+// Authenticate with PureCloud
+function authenticate(client, pcEnvironment) {
+    /*
+    * Note: To use this app in your own org, you will need to create your own OAuth2 Client(s)
+    * in your PureCloud org.  After creating the Implicit grant client, map the client id(s) to
+    * the specified region key(s) in the object below, deploy the page, and configure an app to point to that URL.
+    */
+    const pcOAuthClientIds = {'mypurecloud.com': 'implicit-oauth-client-id-here'};
+    const clientId = pcOAuthClientIds[pcEnvironment];
+    if (!clientId) {
+        return Promise.reject(new Error(pcEnvironment + ': Unknown/Unsupported PureCloud Environment'));
+    }
+
+    const { origin, protocol, host, pathname } = window.location;
+    const redirectUrl = (origin || `${protocol}//${host}`) + pathname;
+
+    return client.loginImplicitGrant(clientId, redirectUrl, {state: `pcEnvironment=${pcEnvironment}`})
+        .then(data => {
+            window.history.replaceState(null, '', `${pathname}?${data.state}`);
+        });
+}


### PR DESCRIPTION
So after some digging, it appears that this issue has always been around and that if you reload the frame on any examples that use the implicit login flow you'll run into issues where the `pcEnvironment` query param will no longer be found. This can be worked around by just hardcoding your `pcEnvironment` in the html/js file, but I like not having to do any setup when starting the dev server being able to start up without any magic or special hidden config/workarounds. Here's why this solves the problem:

1. The URL used in the configuration of an app is `https://localhost:8443/profile.html?pcEnvironment={{pcEnvironment}}`
2. App initially loads at `https://localhost:8443/profile.html?pcEnvironment=mypurecloud.com`
3. App initiates implicit login flow and is redirected after authentication to `https://localhost:8443/profile.html#access_token=...&state=pcEnvironment%253Dmypurecloud.com&token_type=...`
4. We parse the `pcEnvironment` from the hash and the platform client then [parses the access token and clears the hash](https://github.com/MyPureCloud/platform-client-sdk-javascript/blob/708792a0557ddabb6df7a7455b2422d2c5f2bf5f/build/src/purecloud-platform-client-v2/ApiClient.js#L460)
5. Then, after all is done and we are authenticated, I am now manually restoring the query param using `window.history.replaceState` which is an API that allows you to modify the history without reloading the window.

Also, while in here I pulled out a common `authenticate` utility function which is now used in all of the examples where we need to login with the implicit oauth flow.