### PR TITLE
Drop required node engine version to 12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 12.18.0"
+    "node": ">= 12.x"
   },
   "dependencies": {
     "@babel/runtime": "^7.10.3",


### PR DESCRIPTION
We need to drop the required node engine version here since the latest version Jenkins has installed is 12.13.0.