### PR TITLE
ATEAM-111: Add Propose Message Handler + Demo

### DIFF
--- a/examples/proposeMessageDemo.html
+++ b/examples/proposeMessageDemo.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Genesys Cloud Propose Message Demo</title>
+        <script src="https://sdk-cdn.mypurecloud.com/client-apps/1.4.0/purecloud-client-app-sdk-49c1570bfd8967d8861435e0e7178035.min.js"></script>
+        <style>
+            #app {
+                display: flex;
+                flex-direction: column;
+                max-width: 300px;
+            }
+            .button-list, form {
+                display: flex;
+                flex-direction: column;
+                border: 1px solid #ccc;
+                padding: 0 5px;
+            }
+            button, input, div {
+                font-family: Arial, Helvetica, sans-serif;
+                font-size: 16px;
+                margin: 5px 0;
+            }
+            button {
+                border: none;
+                background-color: #2a60c8;
+                color: #fdfdfd;
+                border-radius: 4px;
+                padding: 6px 10px;
+                box-shadow: 1px 1px 4px -1px #666;
+                cursor: pointer;
+            }
+            input {
+                padding: 6px;
+                border-radius: 4px;
+                border: 1px solid #ccc;
+            }
+            button:active {
+                box-shadow: none;
+            }
+            button:disabled {
+                background-color: grey;
+                cursor: not-allowed;
+            }
+        </style>
+    </head>
+    <body>
+        <script>
+        (function () {
+        const clientApp = new window.purecloud.apps.ClientApp({ pcEnvironmentQueryParam: 'pcEnvironment' });
+
+        const html = (htmlStr, template = document.createElement('template')) => {
+            template.innerHTML = htmlStr.trim();
+            return template.content.firstChild;
+        };
+
+        const node = (parent, htmlStr) => parent.appendChild(html(htmlStr));
+
+        const App = node(document.body, `<div id='app' />`);
+
+        const container = node(App, `
+            <div class="button-list">
+                <div class="header">Pre-made:</div>
+            </div>
+        `);
+
+        const precannedButtons = [
+            node(container, `<button>Thank you for contacting us</button`),
+            node(container, `<button>Have a nice day!</button`),
+            node(container, `<button>Let me ask my manager about that</button>`),
+            node(container, `<button>HTML will be <b>Sanitized</b></button>`)
+        ];
+
+        const customResponse = node(App, `
+            <form>
+                <div class="header">Custom:</div>
+                <input type="text" />
+                <button disabled type="submit">Fill</button>
+            </form>
+        `);
+
+        const [,customInput,fillCustomBtn] = customResponse.children;
+        customInput.oninput = e => {
+            fillCustomBtn.disabled = !e.target.value;
+        }
+
+        customResponse.addEventListener('submit', event => {
+            let message = event.target[0].value;
+            console.log('form: ', message);
+            clientApp.conversations.proposeInteractionMessage('insert', message);
+            event.preventDefault();
+        });
+
+        precannedButtons.forEach(button =>
+            button.addEventListener('click', event => {
+                let message = event.target.innerHTML;
+                console.log('button: ', message);
+                clientApp.conversations.proposeInteractionMessage('insert', message);
+            }));
+        }());
+        </script>
+    </body>
+</html>

--- a/src/modules/conversations.ts
+++ b/src/modules/conversations.ts
@@ -35,6 +35,22 @@ class ConversationsApi extends BaseApi {
     showInteractionDetails(conversationId: string) {
         super.sendMsgToPc('showInteractionDetails', {conversationId: conversationId});
     }
+
+    /**
+     * Send a message to be filled into the interaction message box for the agent to review and send.
+     * This function works specifically with a bound interaction when both the interaction and calling app
+     * are visible, it is not intended (and will not work) for situations where the interaction is not active.
+     * Furthermore, this function should only be called in response to user interaction to ensure the agent is
+     * aware of the impending text insertion and so their existing draft state is not unexpectedly altered.
+     * 
+     * @param mode - The insertion mode to use when injecting the text into the agent's text box.
+     * 'insert' -> injects text at agent's cursor position, leaving other text intact.
+     * 
+     * @param message - The message to inject into the agent's text box.
+     */
+    proposeInteractionMessage(mode: 'insert', message: string) {
+        super.sendMsgToPc('proposeInteractionMessage', { mode, message });
+    }
 }
 
 export default ConversationsApi;


### PR DESCRIPTION
The purpose of this SDK method is to fill the agent's active interaction text box. This method will only work with the currently active interaction and when the calling app is the active app. This is to avoid the agent's textbox being changed from multiple sources and so that the agent is aware when the text content has changed.

I mostly just worked off of what Eric had already done here and cleaned up a few things. Also, I branched off of the build-transformations branch here so that I was able to deploy this demo. 