### PR TITLE
ATEAM-287: Conditionally generate a set of html or genesys cloud dev-center docs

### DIFF
--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -1,44 +1,36 @@
-import * as path from "path";
 import * as fs from "fs-extra";
-import { Application, TSConfigReader, TypeDocOptions } from "typedoc";
-import * as yargs from 'yargs';
+import * as yargs from "yargs";
+import { TypeDocOptions } from "typedoc";
+import { buildDevCenterDocs } from "./docs/build-dev-center-docs";
+import { buildHtmlDocs } from "./docs/build-html-docs";
 
-const OUTPUT_DIR = "dist/docs";
-const INDEX_FILE = "doc/index.md";
-const SUPPORTED_DOC_OUTPUT_FORMATS = ['github', 'purecloudDevCenter'] as const;
-
-const { preview: flagDocsAsPreview, format: docMdOutputFormat } = yargs
-    .option('preview', {
-        type: 'boolean',
+const { preview: flagDocsAsPreview, format, outputDir } = yargs
+    .option("preview", {
+        desc: "Whether or not to flag the dev-center docs as preview",
+        type: "boolean",
         default: false
     })
-    .option('format', {
-        choices: SUPPORTED_DOC_OUTPUT_FORMATS,
-        default: 'purecloudDevCenter'
+    .option("format", {
+        choices: ["html", "dev-center"] as const,
+        default: "dev-center"
+    })
+    .option("outputDir", {
+        type: "string",
+        default: "dist/docs"
+    })
+    .check(argv => {
+        if (argv.preview && argv.format !== "dev-center") {
+            throw new Error("--preview can only be used in conjunction with dev-center output format");
+        }
+        return true;
     })
     .argv;
 
-// Options added by the Typedoc Markdown Plugin
-interface MarkdownPluginOptions {
-    skipSidebar: boolean;
-    hideBreadcrumbs: boolean;
-}
-
-type DocsConfig = Partial<TypeDocOptions & MarkdownPluginOptions>;
-
-const docsConfig: DocsConfig = {
+const commonDocsOptions: Partial<TypeDocOptions> = {
     mode: "file",
     name: "Client App SDK",
     logger: 'none',
-    theme: "docusaurus", // Theme that generates output closest to Dev Center format
-    skipSidebar: true, // Disable sidebar generation
     disableSources: true, // Don't show the file for each method/class
-    hideBreadcrumbs: true, // Dev Center handles breadcrumbs for us
-    readme: "none",
-    plugin: [
-        'typedoc-plugin-markdown',
-        'typedoc-plugin-no-inherit'
-    ],
     exclude: [
         "**/utils/**",
         "**/.babelrc",
@@ -52,70 +44,15 @@ const docsConfig: DocsConfig = {
     excludeNotDocumented: true
 };
 
-const transformLinks = (buffer: string, ext: string) => {
-    // Regex to replace the following patterns (ext = "html"):
-    // [link1](api.md) -> [link1](api.html)
-    // [link2](api.md#someref) -> [link2](api.html#someref)
-    return buffer.replace(/(\[[^\]]+\][^)]+)(\.md)(\)|#[^)]*\))/gm, `$1${ext}$3`);
-};
-
-const prependDocHeaderAttribute = (buffer: string, attr: string) => {
-    if (!buffer.startsWith('---')) {
-        throw new Error('Doc header symbol "---" not found');
+try {
+    // Clean output directory
+    fs.removeSync(outputDir);
+    if (format === "dev-center") {
+        buildDevCenterDocs({ flagDocsAsPreview, outputDir, options: commonDocsOptions });
+    } else if (format === "html") {
+        buildHtmlDocs({ outputDir, options: commonDocsOptions });
     }
-    return buffer = `---\n${attr}${buffer.substring('---'.length)}`;
-};
-
-(async () => {
-    const app = new Application();
-
-    // So TypeDoc can load tsconfig.json
-    app.options.addReader(new TSConfigReader());
-
-    app.bootstrap(docsConfig);
-
-    const project = app.convert(app.expandInputFiles(["src"]));
-    if (!project) throw new Error("Unable to generate typedoc project");
-
-    // Rendered docs
-    app.generateDocs(project, OUTPUT_DIR);
-
-    // Flatten typedoc's generated classes folder
-    const classesDir = path.join(OUTPUT_DIR, "classes");
-    const fileNames = await fs.readdir(classesDir);
-    await Promise.all(
-        fileNames.map(async (name) =>
-            fs.rename(path.join(classesDir, name), path.join(OUTPUT_DIR, name))
-        )
-    );
-
-    // Delete typedoc's generated classes folder
-    await fs.remove(classesDir);
-
-    // Use custom index file in place of typedoc's index
-    const indexFilePath = path.join(OUTPUT_DIR, "index.md");
-    await fs.copy(INDEX_FILE, indexFilePath);
-
-    // Add header to index file
-    const indexFileContents = (await fs.readFile(indexFilePath)).toString();
-    await fs.outputFile(indexFilePath, "---\ntitle: Client App SDK\n---\n\n" + indexFileContents);
-
-    // Apply transformations to docs
-    const docs = await fs.readdir(OUTPUT_DIR);
-    await Promise.all(
-        docs.map(async (doc) => {
-            const docPath = path.join(OUTPUT_DIR, doc);
-            let buffer = (await fs.readFile(docPath)).toString();
-            if (docMdOutputFormat === 'purecloudDevCenter') {
-                buffer = transformLinks(buffer, '.html');
-            }
-            if (flagDocsAsPreview) {
-                buffer = prependDocHeaderAttribute(buffer, 'ispreview: true');
-            }
-            return fs.outputFile(docPath, buffer);
-        })
-    );
-})().catch(error => {
+} catch (error) {
     console.error('Documentation generation failed', error);
     process.exit(1);
-});
+}

--- a/scripts/docs/build-dev-center-docs.ts
+++ b/scripts/docs/build-dev-center-docs.ts
@@ -1,0 +1,90 @@
+import * as path from "path";
+import * as fs from "fs-extra";
+import { Application, TSConfigReader, TypeDocOptions } from "typedoc";
+
+const transformLinks = (buffer: string, ext: string) => {
+    // Regex to replace the following patterns (ext = "html"):
+    // [link1](api.md) -> [link1](api.html)
+    // [link2](api.md#someref) -> [link2](api.html#someref)
+    return buffer.replace(/(\[[^\]]+\][^)]+)(\.md)(\)|#[^)]*\))/gm, `$1${ext}$3`);
+};
+
+const prependDocHeaderAttribute = (buffer: string, attr: string) => {
+    if (!buffer.startsWith('---')) {
+        throw new Error('Doc header symbol "---" not found');
+    }
+    return buffer = `---\n${attr}${buffer.substring('---'.length)}`;
+};
+
+// Options added by the Typedoc Markdown Plugin
+interface MarkdownPluginOptions {
+    skipSidebar: boolean;
+    hideBreadcrumbs: boolean;
+}
+
+interface DevCenterDocsOptions {
+    options?: Partial<TypeDocOptions>;
+    flagDocsAsPreview: boolean;
+    outputDir: string;
+}
+
+export const buildDevCenterDocs = async ({ flagDocsAsPreview, outputDir, options }: DevCenterDocsOptions) => {
+    const app = new Application();
+
+    // So TypeDoc can load tsconfig.json
+    app.options.addReader(new TSConfigReader());
+
+    const docsConfig: Partial<TypeDocOptions & MarkdownPluginOptions> = {
+        ...options,
+        theme: "docusaurus", // Theme that generates output closest to Dev Center format
+        skipSidebar: true, // Disable sidebar generation
+        hideBreadcrumbs: true, // Dev Center handles breadcrumbs for us
+        readme: "none",
+        plugin: [
+            'typedoc-plugin-markdown',
+            'typedoc-plugin-no-inherit'
+        ],
+    };
+
+    app.bootstrap(docsConfig);
+
+    const project = app.convert(app.expandInputFiles(["src"]));
+    if (!project) throw new Error("Unable to generate typedoc project");
+
+    // Rendered docs
+    app.generateDocs(project, outputDir);
+
+    // Flatten typedoc's generated classes folder
+    const classesDir = path.join(outputDir, "classes");
+    const fileNames = await fs.readdir(classesDir);
+    await Promise.all(
+        fileNames.map(async (name) =>
+            fs.rename(path.join(classesDir, name), path.join(outputDir, name))
+        )
+    );
+
+    // Delete typedoc's generated classes folder
+    await fs.remove(classesDir);
+
+    // Use custom index file in place of typedoc's index
+    const indexFilePath = path.join(outputDir, "index.md");
+    await fs.copy("doc/index.md", indexFilePath);
+
+    // Add header to index file
+    const indexFileContents = (await fs.readFile(indexFilePath)).toString();
+    await fs.outputFile(indexFilePath, "---\ntitle: Client App SDK\n---\n\n" + indexFileContents);
+
+    // Apply transformations to docs
+    const docs = await fs.readdir(outputDir);
+    await Promise.all(
+        docs.map(async (doc) => {
+            const docPath = path.join(outputDir, doc);
+            let buffer = (await fs.readFile(docPath)).toString();
+            buffer = transformLinks(buffer, '.html');
+            if (flagDocsAsPreview) {
+                buffer = prependDocHeaderAttribute(buffer, 'ispreview: true');
+            }
+            return fs.outputFile(docPath, buffer);
+        })
+    );
+};

--- a/scripts/docs/build-html-docs.ts
+++ b/scripts/docs/build-html-docs.ts
@@ -1,0 +1,28 @@
+import { Application, TSConfigReader, TypeDocOptions } from "typedoc";
+
+interface HtmlDocsOptions {
+    options?: Partial<TypeDocOptions>;
+    outputDir: string;
+}
+
+export const buildHtmlDocs = async ({ outputDir, options }: HtmlDocsOptions) => {
+    const app = new Application();
+
+    // So TypeDoc can load tsconfig.json
+    app.options.addReader(new TSConfigReader());
+
+    app.bootstrap({
+        ...options,
+        theme: 'minimal',
+        readme: 'none',
+        plugin: [
+            'typedoc-plugin-no-inherit'
+        ],
+    });
+
+    const project = app.convert(app.expandInputFiles(["src"]));
+    if (!project) throw new Error("Unable to generate typedoc project");
+
+    // Rendered docs
+    app.generateDocs(project, outputDir);
+};


### PR DESCRIPTION
As @justinaray and I discussed the other day, in addition to building docs specifically for the dev center, we'd like to be able to generate pure set of docs that can be hosted elsewhere. This PR splits our doc generation process based on what format the user specifies. The way it's set up now we should be able to handle HTML and dev-center output formats. We can always choose to add a pure markdown output or something of the sort if we choose later on. This just gives us the initial setup. While I was here I also added a clean step to run before docs generation.