### PR TITLE
ATEAM-321: Target valid platform client environments in examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,9 @@ $ yarn run examples --bundle={BUNDLE_PATH}
 #### CLIENT_APP_SDK_HOST_APP_DEV_ORIGIN
 Specify the full target origin for the `postMessage` request when the host app is running on `localhost`.
 
+### CLIENT_APP_SDK_PC_DEV_PLATFORM_ENV
+Specify the Genesys Cloud environment to target when host app is running on `localhost`. (e.g mypurecloud.com)
+
 #### CLIENT_APP_SDK_PC_DEV_ENVS
 Whitelist additional comma-delimited top level domains (e.g. example.com).
 

--- a/examples/agentInteractionsDemo/app.js
+++ b/examples/agentInteractionsDemo/app.js
@@ -159,9 +159,6 @@ new Vue({
         }
 
         let client = platformClient.ApiClient.instance;
-        client.setEnvironment(pcEnvironment);
-        client.setPersistSettings(true);
-
         let clientApp = null;
         try {
             clientApp = new window.purecloud.apps.ClientApp({

--- a/examples/externalContactsDemo/script.js
+++ b/examples/externalContactsDemo/script.js
@@ -18,8 +18,6 @@ document.addEventListener('DOMContentLoaded', function () {
     updateProgressBar(60);
 
     let client = platformClient.ApiClient.instance;
-    client.setEnvironment(pcEnvironment);
-
     let clientApp = null;
     try {
         clientApp = new window.purecloud.apps.ClientApp({

--- a/examples/interactionsDemo.html
+++ b/examples/interactionsDemo.html
@@ -164,8 +164,6 @@
                 }
 
                 let client = platformClient.ApiClient.instance;
-                client.setEnvironment(pcEnvironment);
-
                 let clientApp = null;
                 try {
                     clientApp = new window.purecloud.apps.ClientApp({

--- a/examples/profile.html
+++ b/examples/profile.html
@@ -104,8 +104,6 @@
 
             let platformClient = window.require('platformClient');
             let client = platformClient.ApiClient.instance;
-            client.setEnvironment(pcEnvironment);
-
             let clientApp = null;
             try {
                 clientApp = new window.purecloud.apps.ClientApp({

--- a/examples/utils/oauth.js
+++ b/examples/utils/oauth.js
@@ -1,15 +1,25 @@
 // Authenticate with Genesys Cloud
 function authenticate(client, pcEnvironment) {
+    // Allow targeting a different environment when host app is running locally
+    const platformEnvironment = pcEnvironment === 'localhost' ? 'mypurecloud.com' : pcEnvironment;
     /*
     * Note: To use this app in your own org, you will need to create your own OAuth2 Client(s)
     * in your Genesys Cloud org.  After creating the Implicit grant client, map the client id(s) to
     * the specified region key(s) in the object below, deploy the page, and configure an app to point to that URL.
     */
     const pcOAuthClientIds = {'mypurecloud.com': 'implicit-oauth-client-id-here'};
-    const clientId = pcOAuthClientIds[pcEnvironment];
+    const clientId = pcOAuthClientIds[platformEnvironment];
     if (!clientId) {
-        return Promise.reject(new Error(pcEnvironment + ': Unknown/Unsupported Genesys Cloud Environment'));
+        const defaultErr = platformEnvironment + ': Unknown/Unsupported Genesys Cloud Environment';
+        const localErr = `
+            The host app is running locally and the target platform client environment was mapped to '${platformEnvironment}'.
+            Ensure that you have an oauth client specified for this environment.
+        `;
+        return Promise.reject(new Error(pcEnvironment === 'localhost' ? localErr : defaultErr));
     }
+
+    client.setEnvironment(platformEnvironment);
+    client.setPersistSettings(true);
 
     const { origin, protocol, host, pathname } = window.location;
     const redirectUrl = (origin || `${protocol}//${host}`) + pathname;

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -4,7 +4,10 @@ const fs = require('fs-extra');
 const path = require('path');
 const glob = require('glob');
 
-const { CLIENT_APP_SDK_PC_OAUTH_CLIENT_IDS: oauthClientIds } = process.env;
+const {
+    CLIENT_APP_SDK_PC_OAUTH_CLIENT_IDS: oauthClientIds,
+    CLIENT_APP_SDK_PC_DEV_PLATFORM_ENV: devPlatformEnv
+} = process.env;
 const BROWSER_FILENAME = `/${pkg.name}.js`;
 
 // Called from command line
@@ -30,11 +33,21 @@ function transformSdkOAuthClientIds(buffer, ids) {
     );
 }
 
+function transformPlatformEnvironment(buffer, env) {
+    return buffer.replace(
+        /(platformEnvironment =)[^;]+;/,
+        `$1 pcEnvironment === 'localhost' ? '${env}' : pcEnvironment;`
+    );
+}
+
 function buildExample(outDir, relativeFilePath, bundleFileName) {
     let buffer = fs.readFileSync(relativeFilePath, 'utf8');
     buffer = transformExampleSdkUrl(buffer, bundleFileName);
     if (oauthClientIds) {
         buffer = transformSdkOAuthClientIds(buffer, oauthClientIds);
+    }
+    if (devPlatformEnv) {
+        buffer = transformPlatformEnvironment(buffer, devPlatformEnv);
     }
     fs.outputFileSync(
         path.join(outDir, relativeFilePath.replace('examples/', '')),


### PR DESCRIPTION
When the host app is running locally, we need a way to specify which environment the platform client should target. This reads from a new env variable `CLIENT_APP_SDK_PC_DEV_PLATFORM_ENV` and is injected as part of the example transformations.