### PR TITLE
ATEAM-273: Add support for internal sdk extensions and pull in service-discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.3",
+    "genesys-cloud-service-discovery-web": "^1.0.1",
     "query-string": "^5.0.0"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,6 +32,7 @@ const {
 // Packages to exclude from esm/cjs bundles
 const EXTERNAL_DEPS = [
     'query-string',
+    'genesys-cloud-service-discovery-web',
     /@babel\/runtime/ // Need to use a regex here: https://github.com/rollup/plugins/issues/475#issuecomment-652416290
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@
  */
 
 import * as queryString from 'query-string';
-import envUtils, { PcEnv } from './utils/env';
+import { lookupPcEnv, PcEnv, DEFAULT_PC_ENV } from './utils/env';
 import AlertingApi from './modules/alerting';
 import LifecycleApi from './modules/lifecycle';
 import CoreUiApi from './modules/ui';
@@ -167,7 +167,7 @@ class ClientApp {
 
         if (!this._pcEnv && !this._customPcOrigin) {
             // Use the default PC environment
-            this._pcEnv = envUtils.DEFAULT_PC_ENV;
+            this._pcEnv = DEFAULT_PC_ENV;
         }
 
         const apiCfg = {
@@ -189,8 +189,8 @@ class ClientApp {
         }
     }
 
-    private lookupEnv = (env: string) => {
-        const pcEnv = envUtils.lookupPcEnv(env, true);
+    protected lookupEnv(env: string, envTlds?: string[], hostAppDevOrigin?: string) {
+        const pcEnv = lookupPcEnv(env, true, envTlds, hostAppDevOrigin);
         if (!pcEnv) throw new Error(`Could not parse '${env}' into a known PureCloud environment`);
         return pcEnv;
     }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,67 +1,67 @@
-const DEFAULT_PC_ENV_TLD = 'mypurecloud.com';
-const PC_ENV_TLDS = [
-    'mypurecloud.com',
-    'mypurecloud.com.au',
-    'mypurecloud.ie',
-    'mypurecloud.jp',
-    'mypurecloud.de',
-    'usw2.pure.cloud',
-    'euw2.pure.cloud',
-    'cac1.pure.cloud',
-    'apne2.pure.cloud',
-    ...__PC_DEV_ENVS__
-];
+import { getEnvironments } from 'genesys-cloud-service-discovery-web';
 
 export interface PcEnv {
     pcEnvTld: string;
     pcAppOrigin: string;
 }
 
-const PC_ENVS = PC_ENV_TLDS.map<PcEnv>(tld => ({
+const buildPcEnv = (tld: string): PcEnv => ({
     pcEnvTld: tld,
     pcAppOrigin: `https://apps.${tld}`
-}));
+});
 
-const [DEFAULT_PC_ENV] = PC_ENVS.filter(env => env.pcEnvTld === DEFAULT_PC_ENV_TLD);
+const DEFAULT_ENV_REGION = 'us-east-1';
 
-export default {
-    DEFAULT_PC_ENV,
+const environments = getEnvironments({ env: ['prod'], status: ['beta', 'stable'] });
 
-    /**
-     * Attempts to locate a PC environment corresponding to the provided search params
-     *
-     * @param pcEnvTld A string representing the Genesys Cloud environment top-level domain to search for
-     * @param lenient When true, trims leading/trailing whitespace, ignores leading '.', and ignores trailing '/'.
-     *
-     * @returns A Genesys Cloud environment object if found; null otherwise.
-     */
-    lookupPcEnv(pcEnvTld: string, lenient = false): PcEnv | null {
-        if (pcEnvTld && typeof pcEnvTld === 'string') {
-            if (pcEnvTld === 'localhost' && __HOST_APP_DEV_ORIGIN__) {
-                return {
-                    pcEnvTld: 'localhost',
-                    pcAppOrigin: __HOST_APP_DEV_ORIGIN__
-                };
+const PC_ENV_TLDS = environments
+    .reduce((tlds, env) => {
+        tlds.push(env.publicDomainName);
+        tlds.push(...env.publicDomainAliases);
+        return tlds;
+    }, [] as string[])
+    .concat(__PC_DEV_ENVS__);
+
+const [defaultEnv] = environments.filter(env => env.region === DEFAULT_ENV_REGION);
+
+export const DEFAULT_PC_ENV = buildPcEnv(defaultEnv.publicDomainName);
+
+/**
+ * Attempts to locate a PC environment corresponding to the provided search params
+ *
+ * @param pcEnvTld A string representing the Genesys Cloud environment top-level domain to search for
+ * @param lenient When true, trims leading/trailing whitespace, ignores leading '.', and ignores trailing '/'.
+ * @param envTlds A string array of all available Genesys Cloud environment top-level domains
+ * @param hostAppDevOrigin The origin to target when the host app is running on `localhost`
+ *
+ * @returns A Genesys Cloud environment object if found; null otherwise.
+ */
+export const lookupPcEnv = (pcEnvTld: string, lenient = false, envTlds: string[] = PC_ENV_TLDS, hostAppDevOrigin = __HOST_APP_DEV_ORIGIN__): PcEnv | null => {
+    if (pcEnvTld && typeof pcEnvTld === 'string') {
+        if (pcEnvTld === 'localhost' && hostAppDevOrigin) {
+            return {
+                pcEnvTld: 'localhost',
+                pcAppOrigin: hostAppDevOrigin
+            };
+        }
+        let toSearch = pcEnvTld;
+
+        if (lenient) {
+            toSearch = toSearch.trim();
+
+            if (toSearch.indexOf('.') === 0) {
+                toSearch = toSearch.substring(1);
             }
-            let toSearch = pcEnvTld;
 
-            if (lenient) {
-                toSearch = toSearch.trim();
-
-                if (toSearch.indexOf('.') === 0) {
-                    toSearch = toSearch.substring(1);
-                }
-
-                if (toSearch.indexOf('/') === (toSearch.length - 1)) {
-                    toSearch = toSearch.substring(0, toSearch.length - 1);
-                }
-            }
-
-            for (const env of PC_ENVS) {
-                if (env.pcEnvTld === toSearch) return env;
+            if (toSearch.indexOf('/') === (toSearch.length - 1)) {
+                toSearch = toSearch.substring(0, toSearch.length - 1);
             }
         }
 
-        return null;
+        if (envTlds.indexOf(toSearch) >= 0) {
+            return buildPcEnv(toSearch);
+        }
     }
+
+    return null;
 };

--- a/src/utils/envSpec.ts
+++ b/src/utils/envSpec.ts
@@ -1,34 +1,39 @@
 import * as envUtils from './env';
 
 export default describe('env utils', () => {
-    const VALID_PC_TLDS = [
-        'mypurecloud.com',
-        'mypurecloud.com.au',
-        'mypurecloud.ie',
-        'mypurecloud.jp',
-        'mypurecloud.de',
-        'usw2.pure.cloud',
-        'euw2.pure.cloud',
-        'cac1.pure.cloud',
-        'apne2.pure.cloud'
-    ];
-
     it('should provide the default environment', () => {
         expect(envUtils.DEFAULT_PC_ENV.pcEnvTld).toBe('mypurecloud.com');
         expect(envUtils.DEFAULT_PC_ENV.pcAppOrigin).toBe('https://apps.mypurecloud.com');
     });
 
-    it('should parse valid TLDs and return the environment object', () => {
-        VALID_PC_TLDS.forEach(currTld => {
-            const resolvedEnv = envUtils.lookupPcEnv(currTld)!;
-            expect(resolvedEnv).not.toBeNull();
-            expect(resolvedEnv.pcEnvTld).toBe(currTld);
-            expect(resolvedEnv.pcAppOrigin).toBe(`https://apps.${currTld}`);
-        });
+    it('should parse a valid TLD and return the environment object', () => {
+        const resolvedEnv = envUtils.lookupPcEnv('mypurecloud.com')!;
+        expect(resolvedEnv).not.toBeNull();
+        expect(resolvedEnv.pcEnvTld).toBe('mypurecloud.com');
+        expect(resolvedEnv.pcAppOrigin).toBe('https://apps.mypurecloud.com');
+    });
+
+    it('should resolve a local environment object with a custom dev origin if passed', () => {
+        const env = envUtils.lookupPcEnv('localhost', true, [], 'https://localhost:3000')!;
+        expect(env).not.toBeNull();
+        expect(env.pcEnvTld).toBe('localhost');
+        expect(env.pcAppOrigin).toBe('https://localhost:3000');
+    });
+
+    it('should resolve an env when in the list of TLDs passed in via param', () => {
+        const resolvedEnv = envUtils.lookupPcEnv('example.com', true, ['example.com'])!;
+        expect(resolvedEnv).not.toBeNull();
+        expect(resolvedEnv.pcEnvTld).toBe('example.com');
+        expect(resolvedEnv.pcAppOrigin).toBe('https://apps.example.com');
+    });
+
+    it('should not resolve an env when it is not in the list of TLDs passed in via param', () => {
+        const env = envUtils.lookupPcEnv('example2.com', true, ['example.com']);
+        expect(env).toBeNull();
     });
 
     it('should allow lenient parsing of TLDs and return the environment object', () => {
-        const seedTld = VALID_PC_TLDS[0];
+        const seedTld = 'mypurecloud.com';
 
         const variations = [
             ` ${seedTld}`, // Leading whitespace
@@ -51,7 +56,7 @@ export default describe('env utils', () => {
     });
 
     it('should return null if the pcEnvTld cannot be parsed or is unknown', () => {
-        const seedTld = VALID_PC_TLDS[0];
+        const seedTld = 'mypurecloud.com';
 
         const variations = [
             undefined,

--- a/src/utils/envSpec.ts
+++ b/src/utils/envSpec.ts
@@ -1,4 +1,4 @@
-import envUtils from './env';
+import * as envUtils from './env';
 
 export default describe('env utils', () => {
     const VALID_PC_TLDS = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2572,6 +2572,13 @@ generate-object-property@^1.1.0:
   dependencies:
     is-property "^1.0.0"
 
+genesys-cloud-service-discovery-web@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/genesys-cloud-service-discovery-web/-/genesys-cloud-service-discovery-web-1.0.1.tgz#9168159633b3c5a028da91d1ff5f11f06838590f"
+  integrity sha512-bYED0YGBE3EBjfSegOxydtPnhLfgOjV+DOD/D7LiiclBg7wnmbAlgYru1fm09N6/Rpf2Vxq3K03Qfq7uPozDDA==
+  dependencies:
+    url-parse "^1.4.7"
+
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
@@ -4086,6 +4093,11 @@ query-string@^5.0.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -5175,6 +5187,14 @@ uri-js@^4.2.2:
   integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
+
+url-parse@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
+  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 url2@^0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Modify the signature of lookupEnv so that we can reuse and override it in the internal SDK class and pull in service discovery