### PR TITLE
ATEAM-601: Improve jsdoc deprecations for users module/methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ class ClientApp {
      * clientApp.users.someMethod(...);
      * ```
      *
-     * @deprecated Since 2.3.0.  @see [directory](#directory) for replacements
+     * @deprecated Use {@link directory} property instead. (Since 2.3.0)
      */
     users: UsersApi;
 

--- a/src/modules/users.ts
+++ b/src/modules/users.ts
@@ -3,7 +3,7 @@
  *
  * @since 1.0.0
  *
- * @deprecated Since 2.3.0. @see The [Directory Module](directoryapi.md) for replacements.
+ * @deprecated Use {@link module:directory} instead. (Since 2.3.0)
  */
 
 import BaseApi from './base';
@@ -14,7 +14,7 @@ import BaseApi from './base';
  * @noInheritDoc
  * @since 1.0.0
  *
- * @deprecated Since 2.3.0.  @see [DirectoryApi](directoryapi.md) for replacements.
+ * @deprecated Use {@link DirectoryApi} instead. (Since 2.3.0)
  */
 class UsersApi extends BaseApi {
     /**
@@ -28,7 +28,9 @@ class UsersApi extends BaseApi {
      *
      * @since 1.0.0
      *
-     * @deprecated Since 2.3.0. @see [DirectoryApi#showUser](directoryapi.md#showuser) for a replacement.
+     * @deprecated Use {@link ClientApp#directory#showUser} instead. (Since 2.3.0)
+     *
+     * @see [DirectoryApi#showUser](directoryapi.md#showuser) for a replacement.
      */
     showProfile(userId: string) {
         super.sendMsgToPc('showProfile', {'profileId': userId});


### PR DESCRIPTION
Tailor @deprecation readability and links for developers inside editors
Keep @see tags only when needed for doc links or ambiguous deprecation instructions