### PR TITLE
fix(examples proposeMessage): fix target handling in example event li…

### DIFF
--- a/examples/proposeMessageDemo.html
+++ b/examples/proposeMessageDemo.html
@@ -84,7 +84,7 @@
         }
 
         customResponse.addEventListener('submit', event => {
-            let message = event.target[0].value;
+            let message = event.currentTarget[0].value;
             console.log('form: ', message);
             clientApp.conversations.proposeInteractionMessage('insert', message);
             event.preventDefault();
@@ -92,7 +92,7 @@
 
         precannedButtons.forEach(button =>
             button.addEventListener('click', event => {
-                let message = event.target.innerHTML;
+                let message = event.currentTarget.innerHTML;
                 console.log('button: ', message);
                 clientApp.conversations.proposeInteractionMessage('insert', message);
             }));


### PR DESCRIPTION
…steners

Switch to currentTarget to get the event listener node vs the clicked
node.  This caused nested HTML inside the demo string buttons to get
sent versus the innerHTML of the entire button.