### PR TITLE
Bump sd-web up to pick up stable Sao Paulo

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.3",
-    "genesys-cloud-service-discovery-web": "^3.0.60",
+    "genesys-cloud-service-discovery-web": "^3.0.68",
     "query-string": "^5.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2060,10 +2060,10 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-genesys-cloud-service-discovery-web@^3.0.60:
-  version "3.0.60"
-  resolved "https://registry.yarnpkg.com/genesys-cloud-service-discovery-web/-/genesys-cloud-service-discovery-web-3.0.60.tgz#cc1c5778a128d7440ce3559640060e9f88d99b5b"
-  integrity sha512-+3irTf21M1FZ7FjKRCpP+8NWElH7ZYDSPV8FO5kMHak7n2tz8E06+k5dzIvldY08/xlJsy6Crv/Bcm7yffGwjA==
+genesys-cloud-service-discovery-web@^3.0.68:
+  version "3.0.68"
+  resolved "https://registry.yarnpkg.com/genesys-cloud-service-discovery-web/-/genesys-cloud-service-discovery-web-3.0.68.tgz#c8cb0843fa64795090ea6dae89f33812790ba779"
+  integrity sha512-cvRaWpk+7QlSbA+EbZleIkdC4kdrrtlU13CDRNCKJiD1LhDTyOqru4Izmpe2tFR264xbL7AWIaqTVFQCSvBsMQ==
   dependencies:
     tslib "~2.4.0"
     url-parse "^1.5.10"


### PR DESCRIPTION
Just a small bump to pick up the latest sd-web with Sao Paulo being stable.

This isn't technically necessary for env parsing as Sao Paulo was beta and would parse fine.  But, best to keep it up-to-date.