### PR TITLE
Consume host origin and target env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Development Utils
 sslcert-dev
+.env
 
 # compiled output
 /dist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,14 @@ Whitelist additional comma-delimited top level domains (e.g. example.com).
 
 #### CLIENT_APP_SDK_GC_EXTRA_ENVS
 Adds a list of Genesys Cloud environments that should be supported.
+``` json
+[
+    {
+        "env": "dev",
+        "publicDomainName": "some-domain-name.ext"
+    }
+]
+```
 
 #### CLIENT_APP_SDK_PC_OAUTH_CLIENT_IDS
 Specify a JSON string mapping environment to OAuth client id to be injected into example html files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,9 @@ Specify the Genesys Cloud environment to target when host app is running on `loc
 #### CLIENT_APP_SDK_PC_DEV_ENVS
 Whitelist additional comma-delimited top level domains (e.g. example.com).
 
+#### CLIENT_APP_SDK_GC_EXTRA_ENVS
+Adds a list of Genesys Cloud environments that should be supported.
+
 #### CLIENT_APP_SDK_PC_OAUTH_CLIENT_IDS
 Specify a JSON string mapping environment to OAuth client id to be injected into example html files.
 ```json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Adds a list of Genesys Cloud environments that should be supported.
 [
     {
         "env": "dev",
-        "publicDomainName": "some-domain-name.ext"
+        "publicDomainName": "some-domain-name.tld"
     }
 ]
 ```

--- a/dev.rollup.config.js
+++ b/dev.rollup.config.js
@@ -6,8 +6,10 @@ import path from 'path';
 import serve from 'rollup-plugin-serve';
 import livereload from 'rollup-plugin-livereload';
 import { umdConfig } from './rollup.config';
+
 const { buildExample, buildExamples } = require('./scripts/build-examples');
 
+const examplesPath = path.resolve('examples');
 const tmpDestPath = fs.mkdtempSync(path.join(os.tmpdir(), `${pkg.name}-dev-server-`));
 
 let httpsConfig;
@@ -21,14 +23,15 @@ try {
 }
 
 const tsc = () => {
-    return new Promise((resolve) => {
-        const bin = require.resolve('typescript/bin/tsc');
+    return new Promise((resolve, reject) => {
+        const bin = process.platform === 'win32' ? require.resolve('.bin/tsc.cmd') : require.resolve('.bin/tsc');
         spawn(bin, [
             '--incremental',
             '--outDir', `${tmpDestPath}/ts-build`,
             '--project', 'tsconfig.build.json'
         ], { stdio: 'inherit' })
-            .on('exit', resolve);
+            .on('exit', resolve)
+            .on('error', (err) => reject(err));
     });
 };
 
@@ -40,20 +43,21 @@ export default Object.assign({}, umdConfig, {
         dir: tmpDestPath
     }),
     watch: {
-        clearScreen: false
+        clearScreen: false,
     },
     plugins: [
         ...umdConfig.plugins,
         {
             name: 'process-examples',
             async buildStart() {
-                this.addWatchFile(path.resolve('examples'));
+                this.addWatchFile(examplesPath);
                 await tsc(); // Check typescript types
             },
             watchChange(id) {
                 // Rebuild individual example file when changed
-                if (id.indexOf('examples/') < 0) return;
-                buildExample(tmpDestPath, path.relative(__dirname, id));
+                if (id.startsWith(examplesPath)) {
+                    buildExample(tmpDestPath, path.relative(__dirname, id));
+                }
             }
         },
         serve({

--- a/dev.rollup.config.js
+++ b/dev.rollup.config.js
@@ -43,7 +43,7 @@ export default Object.assign({}, umdConfig, {
         dir: tmpDestPath
     }),
     watch: {
-        clearScreen: false,
+        clearScreen: false
     },
     plugins: [
         ...umdConfig.plugins,

--- a/examples/toast.html
+++ b/examples/toast.html
@@ -160,10 +160,20 @@
                 // Note: This manual check for query string is for backwards compatibility of this
                 // deployed example.  In your own apps, you can assume the query param will be
                 // provided by Genesys Cloud if you have configured it in your app's config.
-                let envQueryParamName = 'pcEnvironment';
-                if (window && window.location && typeof window.location.search === 'string' &&
-                    window.location.search.indexOf(envQueryParamName) >= 0) {
-                    myClientApp = new window.purecloud.apps.ClientApp({pcEnvironmentQueryParam: envQueryParamName});
+                const envQueryParamName = 'pcEnvironment';
+                const hostQueryParamName = 'gcHostOrigin';
+                const targetEnvQueryParamName = 'gcTargetEnv';
+                const locationSearch = (window && window.location && typeof window.location.search === 'string') ? window.location.search : '';
+                const queryParams = new URLSearchParams(locationSearch);
+                if (queryParams.get(hostQueryParamName) && queryParams.get(targetEnvQueryParamName)) {
+                    // Compute Genesys Cloud region from host origin
+                    myClientApp = new window.purecloud.apps.ClientApp({
+                        gcHostOriginQueryParam: hostQueryParamName,
+                        gcTargetEnvQueryParam: targetEnvQueryParamName
+                    });
+                } else if (queryParams.get(envQueryParamName)) {
+                    // Compute Genesys Cloud region from pcEnvironment
+                    myClientApp = new window.purecloud.apps.ClientApp({ pcEnvironmentQueryParam: envQueryParamName });
                 } else {
                     // Use default Genesys Cloud region
                     myClientApp = new window.purecloud.apps.ClientApp();

--- a/examples/toast.html
+++ b/examples/toast.html
@@ -165,7 +165,7 @@
                 const targetEnvQueryParamName = 'gcTargetEnv';
                 const locationSearch = (window && window.location && typeof window.location.search === 'string') ? window.location.search : '';
                 const queryParams = new URLSearchParams(locationSearch);
-                if (queryParams.get(hostQueryParamName) && queryParams.get(targetEnvQueryParamName)) {
+                if (queryParams.get(hostQueryParamName) || queryParams.get(targetEnvQueryParamName)) {
                     // Compute Genesys Cloud region from host origin
                     myClientApp = new window.purecloud.apps.ClientApp({
                         gcHostOriginQueryParam: hostQueryParamName,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,6 +14,18 @@ const {
     BROWSER_NO_ACTIVITY_TIMEOUT: browserNoActivityTimeoutArg
 } = process.env;
 
+// Add an env specifically for unit testing purposes
+const unitTestingEnv = {
+    "name": "prod-unit-testing",
+    "env": "prod",
+    "region": "un-it-1",
+    "status": "beta",
+    "publicDomainName": "unit1.pure.cloud",
+    "publicDomainAliases": [
+        "unit1.test.ftw"
+    ]
+};
+
 module.exports = (config) => {
     config.set({
         // base path that will be used to resolve all patterns (eg. files, exclude)
@@ -60,7 +72,7 @@ module.exports = (config) => {
                     '__PACKAGE_VERSION__': JSON.stringify(npm_package_version),
                     '__HOST_APP_DEV_ORIGIN__': JSON.stringify(devOrigin),
                     '__PC_DEV_ENVS__': JSON.stringify(devEnvs ? devEnvs.split(',') : []),
-                    '__GC_DEV_EXTRA_ENVS__': extraEnvs || '[]',
+                    '__GC_DEV_EXTRA_ENVS__': JSON.stringify([...(extraEnvs ? JSON.parse(extraEnvs) : []), unitTestingEnv])
                 }),
                 commonjs(),
                 resolve({

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,6 +10,7 @@ const {
     npm_package_version,
     CLIENT_APP_SDK_HOST_APP_DEV_ORIGIN: devOrigin,
     CLIENT_APP_SDK_PC_DEV_ENVS: devEnvs,
+    CLIENT_APP_SDK_GC_EXTRA_ENVS: extraEnvs,
     BROWSER_NO_ACTIVITY_TIMEOUT: browserNoActivityTimeoutArg
 } = process.env;
 
@@ -59,6 +60,7 @@ module.exports = (config) => {
                     '__PACKAGE_VERSION__': JSON.stringify(npm_package_version),
                     '__HOST_APP_DEV_ORIGIN__': JSON.stringify(devOrigin),
                     '__PC_DEV_ENVS__': JSON.stringify(devEnvs ? devEnvs.split(',') : []),
+                    '__GC_DEV_EXTRA_ENVS__': extraEnvs || '[]',
                 }),
                 commonjs(),
                 resolve({

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@typescript-eslint/eslint-plugin": "^3.2.0",
     "@typescript-eslint/parser": "^3.2.0",
     "child-process-promise": "^2.0.2",
+    "dotenv": "^16.0.3",
     "eslint": "^7.2.0",
     "eslint-config-standard": "^11.0.0-beta.0",
     "eslint-plugin-import": "^2.8.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,10 @@ import babel from '@rollup/plugin-babel';
 import resolve from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
 import replace from '@rollup/plugin-replace';
+import dotenv from 'dotenv';
+
+// Get .env variables
+dotenv.config();
 
 const DEST_DIR = 'dist';
 const GLOBAL_LIBRARY_NAME = 'purecloud.apps.ClientApp';
@@ -26,7 +30,8 @@ const {
     npm_package_name,
     npm_package_version,
     CLIENT_APP_SDK_HOST_APP_DEV_ORIGIN: devOrigin,
-    CLIENT_APP_SDK_PC_DEV_ENVS: devEnvs
+    CLIENT_APP_SDK_PC_DEV_ENVS: devEnvs,
+    CLIENT_APP_SDK_GC_EXTRA_ENVS: extraEnvs
 } = process.env;
 
 // Packages to exclude from esm/cjs bundles
@@ -59,6 +64,7 @@ const baseRollupConfig = {
             '__PACKAGE_VERSION__': JSON.stringify(npm_package_version),
             '__HOST_APP_DEV_ORIGIN__': JSON.stringify(devOrigin),
             '__PC_DEV_ENVS__': JSON.stringify(devEnvs ? devEnvs.split(',') : []),
+            '__GC_DEV_EXTRA_ENVS__': extraEnvs || '[]',
         }),
         commonjs(),
         resolve({ extensions: ['.js', '.ts'] }),

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -9,7 +9,6 @@ const {
     CLIENT_APP_SDK_PC_DEV_PLATFORM_ENV: devPlatformEnv
 } = process.env;
 const BROWSER_FILENAME = `/${pkg.name}.js`;
-const examplesPath = path.resolve('examples');
 
 // Called from command line
 if (!module.parent) {
@@ -60,9 +59,8 @@ function buildExample(outDir, relativeFilePath, bundleFileName) {
             buffer = transformPlatformEnvironment(buffer, devPlatformEnv);
         }
     }
-
     fs.outputFileSync(
-        path.join(outDir, path.relative(examplesPath, relativeFilePath)),
+        path.join(outDir, relativeFilePath.replace(/examples[/|\\]/, '')),
         buffer
     );
 }

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -9,6 +9,7 @@ const {
     CLIENT_APP_SDK_PC_DEV_PLATFORM_ENV: devPlatformEnv
 } = process.env;
 const BROWSER_FILENAME = `/${pkg.name}.js`;
+const examplesPath = path.resolve('examples');
 
 // Called from command line
 if (!module.parent) {
@@ -61,7 +62,7 @@ function buildExample(outDir, relativeFilePath, bundleFileName) {
     }
 
     fs.outputFileSync(
-        path.join(outDir, relativeFilePath.replace('examples/', '')),
+        path.join(outDir, path.relative(examplesPath, relativeFilePath)),
         buffer
     );
 }
@@ -69,7 +70,7 @@ function buildExample(outDir, relativeFilePath, bundleFileName) {
 function buildExamples(outDir, bundleFileName) {
     glob
         .sync('examples/**/*', { nodir: true })
-        .forEach(example => buildExample(outDir, example, bundleFileName));
+        .forEach((example) => buildExample(outDir, path.normalize(example), bundleFileName));
 }
 
 module.exports = { buildExample, buildExamples };

--- a/src/ClientAppSpec.ts
+++ b/src/ClientAppSpec.ts
@@ -183,7 +183,7 @@ export default describe('ClientApp', () => {
                         gcTargetEnvQueryParam: 'gcTargetEnv'
                     });
                 }).toThrow();
-                // Localhost
+                // Invalid target env 
                 query = '?gcHostOrigin=https://apps.mypurecloud.com&gcTargetEnv=invalid';
                 expect(() => {
                     new ClientApp({

--- a/src/ClientAppSpec.ts
+++ b/src/ClientAppSpec.ts
@@ -169,7 +169,6 @@ export default describe('ClientApp', () => {
                 }).toThrow();
                 // External
                 query = '?gcHostOrigin=https://invalid.com&gcTargetEnv=prod';
-                spyOn(ClientApp, '_getQueryString').and.callFake(() => query);
                 expect(() => {
                     new ClientApp({
                         gcHostOriginQueryParam: 'gcHostOrigin',

--- a/src/ClientAppSpec.ts
+++ b/src/ClientAppSpec.ts
@@ -158,8 +158,17 @@ export default describe('ClientApp', () => {
                 expect(myClientApp.pcEnvironment).toBe('localhost');
             });
             it('should fail if is not targeting a valid env', () => {
+                // Mismatch
+                let query = '?gcHostOrigin=https://apps.mypurecloud.jp&gcTargetEnv=prod';
+                spyOn(ClientApp, '_getQueryString').and.callFake(() => query);
+                expect(() => {
+                    new ClientApp({
+                        gcHostOriginQueryParam: 'gcHostOrigin',
+                        gcTargetEnvQueryParam: 'gcTargetEnv'
+                    });
+                }).toThrow();
                 // External
-                let query = '?gcHostOrigin=https://invalid.com&gcTargetEnv=prod';
+                query = '?gcHostOrigin=https://invalid.com&gcTargetEnv=prod';
                 spyOn(ClientApp, '_getQueryString').and.callFake(() => query);
                 expect(() => {
                     new ClientApp({

--- a/src/ClientAppSpec.ts
+++ b/src/ClientAppSpec.ts
@@ -158,9 +158,17 @@ export default describe('ClientApp', () => {
                 expect(myClientApp.pcEnvironment).toBe('localhost');
             });
             it('should fail if is not targeting a valid env', () => {
-                // Mismatch
+                // Mismatch Environment
                 let query = '?gcHostOrigin=https://apps.mypurecloud.jp&gcTargetEnv=prod';
                 spyOn(ClientApp, '_getQueryString').and.callFake(() => query);
+                expect(() => {
+                    new ClientApp({
+                        gcHostOriginQueryParam: 'gcHostOrigin',
+                        gcTargetEnvQueryParam: 'gcTargetEnv'
+                    });
+                }).toThrow();
+                // Mismatch Localhost
+                query = '?gcHostOrigin=https://localhost:1337&gcTargetEnv=unknown';
                 expect(() => {
                     new ClientApp({
                         gcHostOriginQueryParam: 'gcHostOrigin',

--- a/src/ClientAppSpec.ts
+++ b/src/ClientAppSpec.ts
@@ -139,6 +139,90 @@ export default describe('ClientApp', () => {
                 });
             });
         });
+        describe('gcHostOriginQueryParam and gcTargetEnvQueryParam config', () => {
+            it('should allow a user to pass valid query param names into the constructor', () => {
+                // External
+                let query = '?gcHostOrigin=https://apps.mypurecloud.com&gcTargetEnv=prod';
+                spyOn(ClientApp, '_getQueryString').and.callFake(() => query);
+                let myClientApp = new ClientApp({
+                    gcHostOriginQueryParam: 'gcHostOrigin',
+                    gcTargetEnvQueryParam: 'gcTargetEnv'
+                });
+                expect(myClientApp.pcEnvironment).toBe('mypurecloud.com');
+                // Localhost
+                query = '?gcHostOrigin=https://localhost:1337&gcTargetEnv=prod';
+                myClientApp = new ClientApp({
+                    gcHostOriginQueryParam: 'gcHostOrigin',
+                    gcTargetEnvQueryParam: 'gcTargetEnv'
+                });
+                expect(myClientApp.pcEnvironment).toBe('localhost');
+            });
+            it('should fail if is not targeting a valid env', () => {
+                // External
+                let query = '?gcHostOrigin=https://invalid.com&gcTargetEnv=prod';
+                spyOn(ClientApp, '_getQueryString').and.callFake(() => query);
+                expect(() => {
+                    new ClientApp({
+                        gcHostOriginQueryParam: 'gcHostOrigin',
+                        gcTargetEnvQueryParam: 'gcTargetEnv'
+                    });
+                }).toThrow();
+                // Localhost
+                query = '?gcHostOrigin=https://apps.mypurecloud.com&gcTargetEnv=invalid';
+                expect(() => {
+                    new ClientApp({
+                        gcHostOriginQueryParam: 'gcHostOrigin',
+                        gcTargetEnvQueryParam: 'gcTargetEnv'
+                    });
+                }).toThrow();
+            });
+            it('should fail if the query params are badly configured or not set', () => {
+                // Missing gcHostOrigin config option
+                expect(() => {
+                    new ClientApp({ gcHostOriginQueryParam: 'gcHostOrigin' });
+                }).toThrow();
+                // Missing gcTargetEnv config option
+                expect(() => {
+                    new ClientApp({ gcTargetEnvQueryParam: 'gcTargetEnv' });
+                }).toThrow();
+                // Missing gcHostOrigin query param
+                let query = '?gcTargetEnv=prod';
+                spyOn(ClientApp, '_getQueryString').and.callFake(() => query);
+                expect(() => {
+                    new ClientApp({
+                        gcHostOriginQueryParam: 'gcHostOrigin',
+                        gcTargetEnvQueryParam: 'gcTargetEnv'
+                    });
+                }).toThrow();
+                // Missing gcTargetEnv query param
+                query = '?gcHostOrigin=https://apps.mypurecloud.com';
+                expect(() => {
+                    new ClientApp({
+                        gcHostOriginQueryParam: 'gcHostOrigin',
+                        gcTargetEnvQueryParam: 'gcTargetEnv'
+                    });
+                }).toThrow();
+            });
+            it('should fail if the query params are badly configured or not set', () => {
+                const invalidQueryParamNames = [undefined, null, 3, [], {}, '', ' '];
+                invalidQueryParamNames.forEach((currInvalidParamName) => {
+                    expect(() => {
+                        new ClientApp({
+                            gcHostOriginQueryParam: 'gcHostOrigin',
+                            // @ts-expect-error
+                            gcTargetEnvQueryParam: currInvalidParamName
+                        });
+                    }).toThrow();
+                    expect(() => {
+                        new ClientApp({
+                            gcTargetEnvQueryParam: 'gcTargetEnv',
+                            // @ts-expect-error
+                            gcHostOriginQueryParam: currInvalidParamName
+                        });
+                    }).toThrow();
+                });
+            });
+        });
         /* eslint-enable no-new */
     });
 });

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,4 +1,5 @@
 declare const __PACKAGE_NAME__: string;
 declare const __PACKAGE_VERSION__: string;
 declare const __PC_DEV_ENVS__: string[];
+declare const __GC_DEV_EXTRA_ENVS__: unknown[];
 declare const __HOST_APP_DEV_ORIGIN__: string;

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,5 +1,7 @@
+type Environment = import('genesys-cloud-service-discovery-web').Environment;
+
 declare const __PACKAGE_NAME__: string;
 declare const __PACKAGE_VERSION__: string;
 declare const __PC_DEV_ENVS__: string[];
-declare const __GC_DEV_EXTRA_ENVS__: unknown[];
+declare const __GC_DEV_EXTRA_ENVS__: Environment[];
 declare const __HOST_APP_DEV_ORIGIN__: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@
  */
 
 import * as queryString from 'query-string';
-import { Environment } from 'genesys-cloud-service-discovery-web';
+import type { Environment } from 'genesys-cloud-service-discovery-web';
 import { lookupPcEnv, lookupGcEnv, PcEnv, DEFAULT_PC_ENV } from './utils/env';
 import AlertingApi from './modules/alerting';
 import LifecycleApi from './modules/lifecycle';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,7 @@
  */
 
 import * as queryString from 'query-string';
-import type { Environment } from 'genesys-cloud-service-discovery-web';
-import { lookupPcEnv, lookupGcEnv, PcEnv, DEFAULT_PC_ENV } from './utils/env';
+import { lookupPcEnv, lookupGcEnv, PcEnv, DEFAULT_PC_ENV, EnvironmentParser } from './utils/env';
 import AlertingApi from './modules/alerting';
 import LifecycleApi from './modules/lifecycle';
 import CoreUiApi from './modules/ui';
@@ -221,8 +220,8 @@ class ClientApp {
         if (!pcEnv) throw new Error(`Could not parse '${env}' into a known PureCloud environment`);
         return pcEnv;
     }
-    protected lookupGcEnv(hostOrigin: string, targetEnv: string, envList?: Environment[]) {
-        const pcEnv = lookupGcEnv(hostOrigin, targetEnv, envList);
+    protected lookupGcEnv(hostOrigin: string, targetEnv: string, parseEnvironment?: EnvironmentParser) {
+        const pcEnv = lookupGcEnv(hostOrigin, targetEnv, parseEnvironment);
         if (!pcEnv) throw new Error(`Could not parse ${hostOrigin} (${targetEnv}) into a known GenesysCloud environment`);
         return pcEnv;
     }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -21,14 +21,14 @@ const PC_ENV_TLDS = environments
         return tlds;
     }, [] as string[])
     .concat(__PC_DEV_ENVS__);
-const GC_ENV_TARGETS = new Set<string>([...environments, ...__GC_DEV_EXTRA_ENVS__].map((e) => e.env));
+const GC_ENV_NAMES = new Set<string>([...environments, ...__GC_DEV_EXTRA_ENVS__].map((e) => e.name));
 
 const [defaultEnv] = environments.filter(env => env.region === DEFAULT_ENV_REGION);
 
 export const DEFAULT_PC_ENV = buildPcEnv(defaultEnv.publicDomainName);
 
-function isKnownTargetEnv(targetEnv: string) {
-    return GC_ENV_TARGETS.has(targetEnv);
+function isKnownEnvName(toCheck: string) {
+    return GC_ENV_NAMES.has(toCheck);
 }
 
 function findPcEnvironment(location: URL, targetEnv: string, parseEnvironment: EnvironmentParser): PcEnv|null {
@@ -101,7 +101,7 @@ export const lookupPcEnv = (pcEnvTld: string, lenient = false, envTlds: string[]
  * @returns A Genesys Cloud environment object if found; null otherwise.
  */
 export const lookupGcEnv = (url: string, targetEnv: string, parseEnvironment: EnvironmentParser = parse): PcEnv|null => {
-    if (!isKnownTargetEnv(targetEnv)) {
+    if (!isKnownEnvName(targetEnv)) {
         return null;
     }
     try {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -42,7 +42,7 @@ function findPcEnvironment(location: URL, targetEnv: string, parseEnvironment: E
         for (const environment of __GC_DEV_EXTRA_ENVS__) {
             const publicDomains = [environment.publicDomainName, ...(environment.publicDomainAliases || [])];
             const matchingDomain = publicDomains.find((p) => location.hostname === p || location.hostname.endsWith(`.${p}`));
-            if (environment.env === targetEnv && matchingDomain) {
+            if (matchingDomain && environment.name === targetEnv) {
                 return {
                     pcEnvTld: environment.publicDomainName,
                     pcAppOrigin: location.origin

--- a/src/utils/envSpec.ts
+++ b/src/utils/envSpec.ts
@@ -5,84 +5,99 @@ export default describe('env utils', () => {
         expect(envUtils.DEFAULT_PC_ENV.pcEnvTld).toBe('mypurecloud.com');
         expect(envUtils.DEFAULT_PC_ENV.pcAppOrigin).toBe('https://apps.mypurecloud.com');
     });
+    describe('lookupPcEnv', () => {
+        it('should parse a valid TLD and return the environment object', () => {
+            const resolvedEnv = envUtils.lookupPcEnv('mypurecloud.com')!;
+            expect(resolvedEnv).not.toBeNull();
+            expect(resolvedEnv.pcEnvTld).toBe('mypurecloud.com');
+            expect(resolvedEnv.pcAppOrigin).toBe('https://apps.mypurecloud.com');
+        });
+        it('should resolve a local environment object with a custom dev origin if passed', () => {
+            const env = envUtils.lookupPcEnv('localhost', true, [], 'https://localhost:3000')!;
+            expect(env).not.toBeNull();
+            expect(env.pcEnvTld).toBe('localhost');
+            expect(env.pcAppOrigin).toBe('https://localhost:3000');
+        });
+        it('should resolve an env when in the list of TLDs passed in via param', () => {
+            const resolvedEnv = envUtils.lookupPcEnv('example.com', true, ['example.com'])!;
+            expect(resolvedEnv).not.toBeNull();
+            expect(resolvedEnv.pcEnvTld).toBe('example.com');
+            expect(resolvedEnv.pcAppOrigin).toBe('https://apps.example.com');
+        });
+        it('should not resolve an env when it is not in the list of TLDs passed in via param', () => {
+            const env = envUtils.lookupPcEnv('example2.com', true, ['example.com']);
+            expect(env).toBeNull();
+        });
+        it('should allow lenient parsing of TLDs and return the environment object', () => {
+            const seedTld = 'mypurecloud.com';
 
-    it('should parse a valid TLD and return the environment object', () => {
-        const resolvedEnv = envUtils.lookupPcEnv('mypurecloud.com')!;
-        expect(resolvedEnv).not.toBeNull();
-        expect(resolvedEnv.pcEnvTld).toBe('mypurecloud.com');
-        expect(resolvedEnv.pcAppOrigin).toBe('https://apps.mypurecloud.com');
-    });
+            const variations = [
+                ` ${seedTld}`, // Leading whitespace
+                `  ${seedTld}`, // Leading multi-whitespace
+                `${seedTld} `, // Trailing whitespace
+                `${seedTld}  `, // Trailing multi-whitespace
+                `   ${seedTld}   `, // Both Leading and Trailing whitespace
+                `.${seedTld}`, // Leading dot
+                ` .${seedTld}`, // Leading whitespace and dot
+                `${seedTld}/`, // Trailing slash
+                `${seedTld}/ `, // Trailing slash and whitespace
+                `  .${seedTld}/  ` // All of the above
+            ];
 
-    it('should resolve a local environment object with a custom dev origin if passed', () => {
-        const env = envUtils.lookupPcEnv('localhost', true, [], 'https://localhost:3000')!;
-        expect(env).not.toBeNull();
-        expect(env.pcEnvTld).toBe('localhost');
-        expect(env.pcAppOrigin).toBe('https://localhost:3000');
-    });
+            variations.forEach(currTld => {
+                const resolvedEnv = envUtils.lookupPcEnv(currTld, true)!;
+                expect(resolvedEnv.pcEnvTld).toBe(seedTld);
+                expect(resolvedEnv.pcAppOrigin).toBe(`https://apps.${seedTld}`);
+            });
+        });
+        it('should return null if the pcEnvTld cannot be parsed or is unknown', () => {
+            const seedTld = 'mypurecloud.com';
 
-    it('should resolve an env when in the list of TLDs passed in via param', () => {
-        const resolvedEnv = envUtils.lookupPcEnv('example.com', true, ['example.com'])!;
-        expect(resolvedEnv).not.toBeNull();
-        expect(resolvedEnv.pcEnvTld).toBe('example.com');
-        expect(resolvedEnv.pcAppOrigin).toBe('https://apps.example.com');
-    });
+            const variations = [
+                undefined,
+                null,
+                3,
+                {foo: 1},
+                [],
+                '', // Empty string
+                ' ', // Blank string
+                `apps.${seedTld}`, // Subdomain
+                `https://apps.${seedTld}`, // FQDN
+                `. ${seedTld} /`, // Inner whitespace
+                'mypurecloud.io', // Valid TLD, but invalid PC Env TLD
+                'mypurecloud.com.evil.com', // Evil subdomains
+                'usw3.pure.cloud' // Valid PC Env TLD, but invalid subdomain
+            ];
 
-    it('should not resolve an env when it is not in the list of TLDs passed in via param', () => {
-        const env = envUtils.lookupPcEnv('example2.com', true, ['example.com']);
-        expect(env).toBeNull();
-    });
+            variations.forEach(currTld => {
+                // @ts-expect-error
+                let resolvedEnv = envUtils.lookupPcEnv(currTld);
+                expect(resolvedEnv).toBe(null);
 
-    it('should allow lenient parsing of TLDs and return the environment object', () => {
-        const seedTld = 'mypurecloud.com';
-
-        const variations = [
-            ` ${seedTld}`, // Leading whitespace
-            `  ${seedTld}`, // Leading multi-whitespace
-            `${seedTld} `, // Trailing whitespace
-            `${seedTld}  `, // Trailing multi-whitespace
-            `   ${seedTld}   `, // Both Leading and Trailing whitespace
-            `.${seedTld}`, // Leading dot
-            ` .${seedTld}`, // Leading whitespace and dot
-            `${seedTld}/`, // Trailing slash
-            `${seedTld}/ `, // Trailing slash and whitespace
-            `  .${seedTld}/  ` // All of the above
-        ];
-
-        variations.forEach(currTld => {
-            const resolvedEnv = envUtils.lookupPcEnv(currTld, true)!;
-            expect(resolvedEnv.pcEnvTld).toBe(seedTld);
-            expect(resolvedEnv.pcAppOrigin).toBe(`https://apps.${seedTld}`);
+                // Doesn't matter if it's lenient
+                // @ts-expect-error
+                resolvedEnv = envUtils.lookupPcEnv(currTld, true);
+                expect(resolvedEnv).toBe(null);
+            });
         });
     });
-
-    it('should return null if the pcEnvTld cannot be parsed or is unknown', () => {
-        const seedTld = 'mypurecloud.com';
-
-        const variations = [
-            undefined,
-            null,
-            3,
-            {foo: 1},
-            [],
-            '', // Empty string
-            ' ', // Blank string
-            `apps.${seedTld}`, // Subdomain
-            `https://apps.${seedTld}`, // FQDN
-            `. ${seedTld} /`, // Inner whitespace
-            'mypurecloud.io', // Valid TLD, but invalid PC Env TLD
-            'mypurecloud.com.evil.com', // Evil subdomains
-            'usw3.pure.cloud' // Valid PC Env TLD, but invalid subdomain
-        ];
-
-        variations.forEach(currTld => {
-            // @ts-expect-error
-            let resolvedEnv = envUtils.lookupPcEnv(currTld);
-            expect(resolvedEnv).toBe(null);
-
-            // Doesn't matter if it's lenient
-            // @ts-expect-error
-            resolvedEnv = envUtils.lookupPcEnv(currTld, true);
-            expect(resolvedEnv).toBe(null);
+    describe('lookupGcEnv', () => {
+        it('should return null if the url cannot be parsed', () => {
+            const variations = [
+                undefined,
+                null,
+                3,
+                {foo: 1},
+                [],
+                '', // Empty string
+                ' ', // Blank string
+                `. https://apps.mypurecloud.io /`, // Inner whitespace
+            ];
+            variations.forEach((currentVariation) => {
+                // @ts-expect-error
+                const resolvedEnv = envUtils.lookupGcEnv(currentVariation, 'prod');
+                expect(resolvedEnv).toBe(null);
+            });
         });
     });
 });

--- a/src/utils/envSpec.ts
+++ b/src/utils/envSpec.ts
@@ -104,6 +104,9 @@ export default describe('env utils', () => {
             expect(envUtils.lookupGcEnv('https://localhost:8443', 'prod-noMatch')).toBe(null);
             expect(envUtils.lookupGcEnv('https://apps.mypurecloud.com', 'prod-noMatch')).toBe(null);
         });
+        it('should fail if the targetOrigin does not match a known environment', () => {
+            expect(envUtils.lookupGcEnv('https://apps.mypurecloud.com.nomatch', 'prod')).toBe(null);
+        });
         it('should allow localhost origins with a valid targetEnv', () => {
             expect(envUtils.lookupGcEnv('http://127.0.0.1:8080', 'prod')).toEqual({
                 pcEnvTld: 'localhost',
@@ -148,6 +151,7 @@ export default describe('env utils', () => {
                 pcEnvTld: 'unit1.pure.cloud',
                 pcAppOrigin: 'https://app.unit1.test.ftw'
             });
+            expect(envUtils.lookupGcEnv('https://app.unit1.test.ftw.nomatch', 'prod-unit-testing')).toBe(null);
         });
     });
 });

--- a/src/utils/envSpec.ts
+++ b/src/utils/envSpec.ts
@@ -134,5 +134,20 @@ export default describe('env utils', () => {
                 pcAppOrigin: 'https://apps.mypurecloud.jp:8443'
             });
         });
+        it('should support custom envs provided via environment variables', () => {
+            // Tests assume a prod-unit-testing env has been configured in this unit testing env (see karma.conf.js)
+            expect(envUtils.lookupGcEnv('https://localhost:8443', 'prod-unit-testing')).toEqual({
+                pcEnvTld: 'localhost',
+                pcAppOrigin: 'https://localhost:8443'
+            });
+            expect(envUtils.lookupGcEnv('https://apps.unit1.pure.cloud', 'prod-unit-testing')).toEqual({
+                pcEnvTld: 'unit1.pure.cloud',
+                pcAppOrigin: 'https://apps.unit1.pure.cloud'
+            });
+            expect(envUtils.lookupGcEnv('https://app.unit1.test.ftw', 'prod-unit-testing')).toEqual({
+                pcEnvTld: 'unit1.pure.cloud',
+                pcAppOrigin: 'https://app.unit1.test.ftw'
+            });
+        });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1673,6 +1673,11 @@ dom-serialize@^2.2.1:
     extend "^3.0.0"
     void-elements "^2.0.0"
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"


### PR DESCRIPTION
Here is a first draft for the host origin and target env support.
This one should be non-breaking, but this implies some duplicated stuff, more info below.
Here is a short description of what has been added:

- `.env` file support with [dotenv](https://github.com/motdotla/dotenv)
- New `CLIENT_APP_SDK_GC_EXTRA_ENVS` env variable, that can contain an array of environments
- Various fixes for windows development
- `gcHostOriginQueryParam` and `gcTargetEnvQueryParam` params to construct client app support (must be used together)
- a few unit-tests

About the new `CLIENT_APP_SDK_GC_EXTRA_ENVS`, I think we should remove the existing `CLIENT_APP_SDK_PC_DEV_ENVS` variables, and compute the values from the new one, what do you think?
Also, I only updated the `toast.html` sample, should I do the same for all other samples?