### PR TITLE
Add Environment type for TypeScript export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
  * @since 1.0.0
  */
 
-import { Environment } from 'genesys-cloud-service-discovery-web';
+import type { Environment } from 'genesys-cloud-service-discovery-web';
 import * as queryString from 'query-string';
 import { lookupPcEnv, lookupGcEnv, PcEnv, DEFAULT_PC_ENV } from './utils/env';
 import AlertingApi from './modules/alerting';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@
  * @since 1.0.0
  */
 
+import { Environment } from 'genesys-cloud-service-discovery-web';
 import * as queryString from 'query-string';
 import { lookupPcEnv, lookupGcEnv, PcEnv, DEFAULT_PC_ENV } from './utils/env';
 import AlertingApi from './modules/alerting';

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { getEnvironments } from 'genesys-cloud-service-discovery-web';
+import { getEnvironments, Environment } from 'genesys-cloud-service-discovery-web';
 
 export interface PcEnv {
     pcEnvTld: string;


### PR DESCRIPTION
The Environment type is defined globally in `globals.d.ts` for  `__GC_DEV_EXTRA_ENVS__`, but during build, the type is not added to the `dist/index.d.ts`, making it invalid.
The purpose of this fix is to add a valid export for npm package typings.