### PR TITLE
Add gcEnvironment getter to client app

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -107,7 +107,7 @@ We recommend configuring your app so the PC environment can be seeded into the u
 
 1. When registering your app, configure the URL in the format: https://myapp.mydomain.com?gcHostOrigin=\{\{gcHostOrigin\}\}&gcTargetEnv=\{\{gcTargetEnv\}\}
 1. Include `gcHostOriginQueryParam: 'gcHostOrigin'` and `gcTargetEnvQueryParam: 'gcTargetEnv'` in your ClientApp config to dynamically determine the environment
-1. Use `myClientApp.pcEnvironment` to access the environment later when needed (e.g. to pass to the [Genesys Cloud Platform API Javascript Client](https://developer.mypurecloud.com/api/rest/client-libraries/javascript/index.html)).
+1. Use `myClientApp.gcEnvironment` to access the environment later when needed (e.g. to pass to the [Genesys Cloud Platform API Javascript Client](https://developer.mypurecloud.com/api/rest/client-libraries/javascript/index.html)).
 
 ### Manual Configuration
 

--- a/src/ClientAppSpec.ts
+++ b/src/ClientAppSpec.ts
@@ -30,6 +30,9 @@ export default describe('ClientApp', () => {
             myClientApp = new ClientApp({nonEmptyConfig: true} as any);
             expect(myClientApp.pcEnvironment).toBe(VALID_DEFAULT_PC_ENVIRONMENT);
         });
+        it('should export gcEnvironment', () => {
+            expect(new ClientApp().gcEnvironment).toBe(VALID_DEFAULT_PC_ENVIRONMENT);
+        });
 
         describe('pcEnvironmentQueryParam config', () => {
             it('should allow a user to pass a valid query string param name into the constructor', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,6 +268,18 @@ class ClientApp {
      * @since 1.0.0
      */
     get pcEnvironment() {
+        return this.gcEnvironment;
+    }
+    /**
+     * Returns the gcEnvironment (e.g. mypurecloud.com, mypurecloud.jp) if known; null otherwise.
+     * This value will be available if a valid Genesys Cloud Environment is provided, inferred, or
+     * defaulted from the config passed to this instance.
+     *
+     * @returns the valid Genesys Cloud environment; null if unknown.
+     *
+     * @since 2.6.3
+     */
+    get gcEnvironment() {
         return (this._pcEnv ? this._pcEnv.pcEnvTld : null);
     }
 


### PR DESCRIPTION
The purpose of this change is to add the `gcEnvironment` getter to client apps.
This should be released with `2.6.3`. I also updated the sdk doc to mention this one, but samples have not been updated.