### PR TITLE
ATEAM-1240: AlertingApi toast docs bugfix

### DIFF
--- a/src/modules/alerting.ts
+++ b/src/modules/alerting.ts
@@ -70,7 +70,7 @@ const defaultToastOptions: ToastOptions<ValidMessageType, number> = {
     timeout: 7,
     showCloseButton: true,
     markdownMessage: true
-} as unknown as ToastOptions<ValidMessageType, number>;
+};
 
 /**
  * Handles aspects of alerting and attention of this app with Genesys Cloud
@@ -146,23 +146,23 @@ class AlertingApi extends BaseApi {
         message: string,
         options?: ToastOptions<MessageType, Timeout>
     ) {
-        const ToastOptions = options || defaultToastOptions as ToastOptions<MessageType, Timeout>;
+        const toastOptions = options || defaultToastOptions;
         const messageParams = {
             title,
             message,
             type: 'info'
         };
 
-        if (ToastOptions && typeof ToastOptions === 'object') {
-            if (ToastOptions.type && typeof ToastOptions.type === 'string') {
-                const requestedType = ToastOptions.type.trim().toLowerCase();
+        if (toastOptions && typeof toastOptions === 'object') {
+            if (toastOptions.type && typeof toastOptions.type === 'string') {
+                const requestedType = toastOptions.type.trim().toLowerCase();
 
                 if (isValidMessageType(requestedType)) {
                     messageParams.type = requestedType;
                 }
             }
 
-            const validOptions = pick(ToastOptions, VALID_SUPPLEMENTAL_OPTIONS);
+            const validOptions = pick(toastOptions, VALID_SUPPLEMENTAL_OPTIONS);
             Object.assign(messageParams, validOptions);
         }
 

--- a/src/modules/alerting.ts
+++ b/src/modules/alerting.ts
@@ -65,6 +65,13 @@ type ToastCloseButtonConfig<Timeout extends number> = Timeout extends 0
         showCloseButton?: boolean
     }
 
+const defaultToastOptions: ToastOptions<ValidMessageType, number> = {
+    type: 'info',
+    timeout: 7,
+    showCloseButton: true,
+    markdownMessage: true
+} as unknown as ToastOptions<ValidMessageType, number>;
+
 /**
  * Handles aspects of alerting and attention of this app with Genesys Cloud
  *
@@ -82,6 +89,17 @@ class AlertingApi extends BaseApi {
      * Error toasts (`type: 'error'`) require manual dismissal and must be explictly specified with `showCloseButton: true`.
      * TypeScript users will also specify `timeout: 0` while JavaScript users can specify 0 or omit the prop entirely.
      * The `timeout` prop will be ignored regardless.
+     * 
+     * **Toast Options:**
+     * 
+     * Name | Type | Default | Description |
+     * `id` | string | your app's namespace | The id of the message.  Duplicate IDs will replace each other in the toast display.  All IDs will be namespaced with your app ID to avoid collisions. Default will just be your app's namespace and will not support multiple messages. |
+     * `type` | 'error' &#124; 'info' &#124; 'success' | 'info' | The type of the toast message. |
+     * `markdownMessage` |  boolean | true | Indicates if the message is in MD. |
+     * `timeout` | number | 7 | Time in seconds to show the toast.  Set to `0` to disable automatic dismissal. `timeout` must be `0` for toasts with `type: 'error'`. |
+     * `showCloseButton` | boolean | true | Indicates if the close button should be shown. Must be explicitly set to true when `timeout` is `0`. |
+     * 
+     * The type parameters impact the options config. The `MessageType` type extends `'error' | 'info' | 'success'`, and when it is set to `'error'`, it enforces that `timeout` is `0`. The `Timeout` type extends `number`, and when set to `0` it enforces that `showCloseButton` is `true` to prevent a permanent toast message.
      *
      * ```ts
      * myClientApp.alerting.showToastPopup("Hello world", "Hello world, how are you doing today?");
@@ -113,10 +131,10 @@ class AlertingApi extends BaseApi {
      * };
      * myClientApp.alerting.showToastPopup("Hello world", "Hello :earth_americas: How are *you* doing today?", options);
      * ```
-     *
+     * 
      * @param title - Toast title.
-     * @param message - Toast Message.  Supports emoticons, emoji (unicode, shortcodes) and markdown (with markdwownMessage boolean).
-     * @param options - Additonal toast options.
+     * @param message - Toast Message.  Supports emoticons, emoji (unicode, shortcodes) and markdown (with markdownMessage boolean).
+     * @param options - Additonal toast options. 
      *
      * @since 1.0.0
      */
@@ -126,35 +144,31 @@ class AlertingApi extends BaseApi {
     >(
         title: string,
         message: string,
-        options: ToastOptions<MessageType, Timeout> = {
-            type: 'info',
-            timeout: 7,
-            showCloseButton: true,
-            markdownMessage: true
-        } as unknown as ToastOptions<MessageType, Timeout>
+        options?: ToastOptions<MessageType, Timeout>
     ) {
+        const ToastOptions = options || defaultToastOptions as ToastOptions<MessageType, Timeout>;
         const messageParams = {
             title,
             message,
             type: 'info'
         };
 
-        if (options && typeof options === 'object') {
-            if (options.type && typeof options.type === 'string') {
-                const requestedType = options.type.trim().toLowerCase();
+        if (ToastOptions && typeof ToastOptions === 'object') {
+            if (ToastOptions.type && typeof ToastOptions.type === 'string') {
+                const requestedType = ToastOptions.type.trim().toLowerCase();
 
                 if (isValidMessageType(requestedType)) {
                     messageParams.type = requestedType;
                 }
             }
 
-            const validOptions = pick(options, VALID_SUPPLEMENTAL_OPTIONS);
+            const validOptions = pick(ToastOptions, VALID_SUPPLEMENTAL_OPTIONS);
             Object.assign(messageParams, validOptions);
         }
 
         super.sendMsgToPc('showToast', messageParams);
     }
-
+    
     /**
      * Displays badging for unread messages and notifications
      *


### PR DESCRIPTION
We received some feedback on the showToastPopup docs, and in looking into it I saw a bug as well, so this pr fixes both of these things! 
Current doc: https://developer.genesys.cloud/platform/integrations/client-apps/sdk/alertingapi#showtoastpopup

The customer said that it was unclear what units the toast timeout are in and that they weren't sure of the possible values for the type parameters. Because we do Typescript magic in the file, some of that documentation gets lost and doesn't make it to the markdown. To fix this I explicitly added it to the documentation above the function. I am happy to workshop the wording and formatting, if y'all have any ideas to make things more clear and concise let me know! 

The bug is in the parameters table in the `options` row. We set a default value in the parameters of the function, but we have to type cast it which messes up the formatting. The type case is necessary because we set the default toast type to `'info'` but the Type Parameters could be set to `'error' | 'warn'` for example, which would cause a type error. To fix this I moved the default out of the parameters and set it in the function instead. 

I struggled with getting the docs to build locally, but I used the Developer Center markdown editor to test the changes out and it looks like it's displaying correctly! To see the page for yourself, you can pull this branch, run `npm run docs`, copy the contents of `dist/docs/alertingapi.md` and paste it here: 
https://apicentral.inindca.com/services/developer-center/editor 

I've included screenshots as well. These screenshots don't include the middle code blocks because they have not been changed at all. 

![toastDocs1](https://github.com/MyPureCloud/client-app-sdk/assets/51763164/2b66a6cd-edb0-4169-835f-bcd27bb581ce)
![toastDocs2](https://github.com/MyPureCloud/client-app-sdk/assets/51763164/89220f47-e117-4617-9a5f-4c1310f7b003)

Note: The old way of getting the docs to build locally is correct until the Developer Center gets migrated to Yeti CMS.
